### PR TITLE
Add loadURDF kwargs for flexibility of loading.

### DIFF
--- a/robot_descriptions/loaders/pybullet.py
+++ b/robot_descriptions/loaders/pybullet.py
@@ -25,19 +25,23 @@ from typing import Optional
 import pybullet
 
 
-def load_robot_description(
-    description_name: str,
-    commit: Optional[str] = None,
-) -> int:
-    """Load a robot description in PyBullet.
+def load_robot_description(description_name: str,
+                           basePosition=(0, 0, 0), baseOrientation=(0, 0, 0, 1), flags=-1,
+                           useFixedBase=0, physicsClientId=0, commit=None) -> int:
+    """
+    Load a robot description in PyBullet.
 
     Args:
         description_name: Name of the robot description.
-        commit: If specified, check out that commit from the cloned robot
-            description repository.
+        basePosition: 3D position of the base of the robot in world coordinates.
+        baseOrientation: orientation in quaternion (xyzw) of the base of the robot in world coordinates.
+        flags: int flags for the URDF loading in pybullet.
+        useFixedBase: boolean indicating use a fix joint between world and robot base.
+        physicsClientId: int indicating the pybullet client id.
+        commit: If specified, check out that commit from the cloned robot description repository.
 
     Returns:
-        Identifier of the robot in PyBullet.
+        Integer identifier of the robot in PyBullet.
     """
     if commit is not None:
         os.environ["ROBOT_DESCRIPTION_COMMIT"] = commit
@@ -46,5 +50,7 @@ def load_robot_description(
         raise ValueError(f"{description_name} is not a URDF description")
 
     pybullet.setAdditionalSearchPath(module.PACKAGE_PATH)
-    robot = pybullet.loadURDF(module.URDF_PATH)
+    robot = pybullet.loadURDF(module.URDF_PATH,
+                              basePosition=basePosition, baseOrientation=baseOrientation, flags=flags,
+                              useFixedBase=useFixedBase, physicsClientId=physicsClientId)
     return robot

--- a/robot_descriptions/loaders/pybullet.py
+++ b/robot_descriptions/loaders/pybullet.py
@@ -25,20 +25,21 @@ from typing import Optional
 import pybullet
 
 
-def load_robot_description(description_name: str,
-                           basePosition=(0, 0, 0), baseOrientation=(0, 0, 0, 1), flags=-1,
-                           useFixedBase=0, physicsClientId=0, commit=None) -> int:
+def load_robot_description(
+    description_name: str, commit=None, **kwargs
+) -> int:
     """
     Load a robot description in PyBullet.
 
     Args:
         description_name: Name of the robot description.
-        basePosition: 3D position of the base of the robot in world coordinates.
-        baseOrientation: orientation in quaternion (xyzw) of the base of the robot in world coordinates.
-        flags: int flags for the URDF loading in pybullet.
-        useFixedBase: boolean indicating use a fix joint between world and robot base.
-        physicsClientId: int indicating the pybullet client id.
         commit: If specified, check out that commit from the cloned robot description repository.
+        kwargs: arguments passed to pybullet.loadURDF function, including:
+            basePosition: 3D position of the base of the robot in world coordinates.
+            baseOrientation: orientation in quaternion (xyzw) of the base of the robot in world coordinates.
+            flags: int flags for the URDF loading in pybullet.
+            useFixedBase: boolean indicating use a fix joint between world and robot base.
+            physicsClientId: int indicating the pybullet client id.
 
     Returns:
         Integer identifier of the robot in PyBullet.
@@ -50,7 +51,5 @@ def load_robot_description(description_name: str,
         raise ValueError(f"{description_name} is not a URDF description")
 
     pybullet.setAdditionalSearchPath(module.PACKAGE_PATH)
-    robot = pybullet.loadURDF(module.URDF_PATH,
-                              basePosition=basePosition, baseOrientation=baseOrientation, flags=flags,
-                              useFixedBase=useFixedBase, physicsClientId=physicsClientId)
+    robot = pybullet.loadURDF(module.URDF_PATH, **kwargs)
     return robot


### PR DESCRIPTION
For flexibility of use of the pybullet interface, I added the arguments of the `loadURDF` function so users can load from robot_descriptions the robots in 
- specific base configurations
- specific physics clients 
- using specific loading flags (e.g., collision configuration)
- first joint type (e.g., fixed)