### PR TITLE
Fix Aliengo URDF source

### DIFF
--- a/robot_descriptions/aliengo_mj_description.py
+++ b/robot_descriptions/aliengo_mj_description.py
@@ -12,12 +12,12 @@ from os import path as _path
 from ._cache import clone_to_cache as _clone_to_cache
 
 REPOSITORY_PATH: str = _clone_to_cache(
-    "unitree_ros",
+    "unitree_mujoco",
     commit=_getenv("ROBOT_DESCRIPTION_COMMIT", None),
 )
 
-PACKAGE_PATH: str = _path.join(
-    REPOSITORY_PATH, "robots", "aliengo_description"
-)
+PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "data", "aliengo")
+
+MJCF_PATH: str = _path.join(PACKAGE_PATH, "xml", "aliengo.xml")
 
 URDF_PATH: str = _path.join(PACKAGE_PATH, "urdf", "aliengo.urdf")


### PR DESCRIPTION
This PR updates the URDF configuration for the aliengo robot by switching to the correct source provided by unitree. The previous URDF file erroneously included two floating base joints (`root_joint` and `floating_base`), effectively introducing an unwarranted 7 degrees of freedom (DoF) for each joint.

The issue is evidenced by the following debug output, which highlights the duplication of the JointModelFreeFlyer type:

```
[...]
[DEBUG][morpho_symm.robots.PinSimWrapper] Loaded pinocchio robot model for aliengo_mj. The robot's joints are:
[DEBUG][morpho_symm.robots.PinSimWrapper] 	 -0   universe             joint_type: JointModelRX         nq:1   nv:1   idx_q:-1  idx_v:-1 
[DEBUG][morpho_symm.robots.PinSimWrapper] 	 -1   root_joint           joint_type: JointModelFreeFlyer  nq:7   nv:6   idx_q:0   idx_v:0  
[DEBUG][morpho_symm.robots.PinSimWrapper] 	 -2   floating_base        joint_type: JointModelFreeFlyer  nq:7   nv:6   idx_q:7   idx_v:6  
[DEBUG][morpho_symm.robots.PinSimWrapper] 	 -3   FL_hip_joint         joint_type: JointModelRX         nq:1   nv:1   idx_q:14  idx_v:12 
[DEBUG][morpho_symm.robots.PinSimWrapper] 	 -4   FL_thigh_joint       joint_type: JointModelRUBY       nq:2   nv:1   idx_q:15  idx_v:13 
[...]
```