### PR TITLE
Allow loading variants for MuJoCo descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Description: UFACTORY xArm7 (MJCF) (thanks to @kevinzakka)
+- Description: accept variant keyword for mujoco loader (thanks to @fabinsch)
 
 ### Changed
 

--- a/robot_descriptions/loaders/mujoco.py
+++ b/robot_descriptions/loaders/mujoco.py
@@ -36,19 +36,20 @@ def load_robot_description(
         os.environ.pop("ROBOT_DESCRIPTION_COMMIT", None)
     if not hasattr(module, "MJCF_PATH"):
         raise ValueError(f"{description_name} is not an MJCF description")
-    
+
     def load_model_from_path(path):
         try:
             return mujoco.MjModel.from_xml_path(path)
         except ValueError:
             print(f"{path} not found. Loading default robot model.")
             return None
+
     model_path = module.MJCF_PATH
     if variant is not None:
         path_parts = model_path.split(os.sep)
         path_parts[-1] = f"{variant}.xml"
         variant_path = os.sep.join(path_parts)
         model = load_model_from_path(variant_path)
-        if model: 
+        if model:
             return model
     return load_model_from_path(model_path)

--- a/robot_descriptions/loaders/mujoco.py
+++ b/robot_descriptions/loaders/mujoco.py
@@ -17,6 +17,7 @@ import mujoco
 def load_robot_description(
     description_name: str,
     commit: Optional[str] = None,
+    variant: Optional[str] = "scene",
 ) -> mujoco.MjModel:
     """Load a robot description in MuJoCo.
 
@@ -35,5 +36,19 @@ def load_robot_description(
         os.environ.pop("ROBOT_DESCRIPTION_COMMIT", None)
     if not hasattr(module, "MJCF_PATH"):
         raise ValueError(f"{description_name} is not an MJCF description")
-
-    return mujoco.MjModel.from_xml_path(module.MJCF_PATH)
+    
+    def load_model_from_path(path):
+        try:
+            return mujoco.MjModel.from_xml_path(path)
+        except ValueError:
+            print(f"{path} not found. Loading default robot model.")
+            return None
+    model_path = module.MJCF_PATH
+    if variant is not None:
+        path_parts = model_path.split(os.sep)
+        path_parts[-1] = f"{variant}.xml"
+        variant_path = os.sep.join(path_parts)
+        model = load_model_from_path(variant_path)
+        if model: 
+            return model
+    return load_model_from_path(model_path)

--- a/robot_descriptions/loaders/mujoco.py
+++ b/robot_descriptions/loaders/mujoco.py
@@ -17,7 +17,7 @@ import mujoco
 def load_robot_description(
     description_name: str,
     commit: Optional[str] = None,
-    variant: Optional[str] = "scene",
+    variant: Optional[str] = None,
 ) -> mujoco.MjModel:
     """Load a robot description in MuJoCo.
 

--- a/robot_descriptions/loaders/mujoco.py
+++ b/robot_descriptions/loaders/mujoco.py
@@ -25,6 +25,7 @@ def load_robot_description(
         description_name: Name of the robot description.
         commit: If specified, check out that commit from the cloned robot
             description repository.
+        variant: If specified, load a specific variant of the robot model.
 
     Returns:
         Robot model for MuJoCo.


### PR DESCRIPTION
Hi @stephane-caron ,

thanks for this nice library to load a bunch of robot models with different frameworks. Lately I was trying some mujoco models and I had a quick fix locally to load the `scene.xml` (which was more useful in my case).

I saw #74 and also #62 and thought that a minimal adaptation allowing for both could be the change proposed in this PR.
This adds a `variant` keyword, that I set the `scene` by default. If a robot has no `scene.xml`, it will still just load the pure robot model as define in each specific file per robot. With this solution, we do not have to modify every single file but I am very open to changes and happy to integrate your remarks. 