### PR TITLE
MuJoCo MJX Support - Add Robotiq 2f85 V4 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added 
+
+- Description: Robotiq 2F-85 (MJCF V4)
+
 ## [1.14.0] - 2025-01-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -198,17 +198,18 @@ The DOF column denotes the number of actuated degrees of freedom.
 
 ### End effectors
 
-| Name                          | Robot                 | Maker                      | DOF | Format     |
-|-------------------------------|-----------------------|----------------------------|-----|------------|
-| `allegro_hand_description`    | Allegro Hand          | Wonik Robotics             | 16  | URDF       |
-| `allegro_hand_mj_description` | Allegro Hand          | Wonik Robotics             | 16  | MJCF       |
-| `barrett_hand_description`    | BarrettHand           | Barrett Technology         | 8   | URDF       |
-| `leap_hand_v1`                | LEAP Hand v1          | Carnegie Mellon University | 16  | URDF       |
-| `leap_hand_mj_description`    | LEAP Hand             | Carnegie Mellon University | 16  | MJCF       |
-| `robotiq_2f85_description`    | Robotiq 2F-85         | Robotiq                    | 1   | URDF       |
-| `robotiq_2f85_mj_description` | Robotiq 2F-85         | Robotiq                    | 1   | MJCF       |
-| `shadow_dexee_mj_description` | Shadow DEX-EE         | The Shadow Robot Company   | 12  | MJCF       |
-| `shadow_hand_mj_description`  | Shadow Hand           | The Shadow Robot Company   | 24  | MJCF       |
+| Name                             | Robot                 | Maker                      | DOF | Format     |
+|----------------------------------|-----------------------|----------------------------|-----|------------|
+| `allegro_hand_description`       | Allegro Hand          | Wonik Robotics             | 16  | URDF       |
+| `allegro_hand_mj_description`    | Allegro Hand          | Wonik Robotics             | 16  | MJCF       |
+| `barrett_hand_description`       | BarrettHand           | Barrett Technology         | 8   | URDF       |
+| `leap_hand_v1`                   | LEAP Hand v1          | Carnegie Mellon University | 16  | URDF       |
+| `leap_hand_mj_description`       | LEAP Hand             | Carnegie Mellon University | 16  | MJCF       |
+| `robotiq_2f85_description`       | Robotiq 2F-85         | Robotiq                    | 1   | URDF       |
+| `robotiq_2f85_mj_description`    | Robotiq 2F-85         | Robotiq                    | 1   | MJCF       |
+| `robotiq_2f85_v4_mj_description` | Robotiq 2F-85         | Robotiq                    | 1   | MJCF       |
+| `shadow_dexee_mj_description`    | Shadow DEX-EE         | The Shadow Robot Company   | 12  | MJCF       |
+| `shadow_hand_mj_description`     | Shadow Hand           | The Shadow Robot Company   | 24  | MJCF       |
 
 ### Humanoids
 

--- a/robot_descriptions/_descriptions.py
+++ b/robot_descriptions/_descriptions.py
@@ -115,6 +115,7 @@ DESCRIPTIONS: Dict[str, Description] = {
     "rhea_description": Description(Format.URDF),
     "robotiq_2f85_description": Description(Format.URDF),
     "robotiq_2f85_mj_description": Description(Format.MJCF),
+    "robotiq_2f85_v4_mj_description": Description(Format.MJCF),
     "romeo_description": Description(Format.URDF),
     "sawyer_mj_description": Description(Format.MJCF),
     "shadow_hand_mj_description": Description(Format.MJCF),

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -162,7 +162,7 @@ REPOSITORIES: Dict[str, Repository] = {
     ),
     "mujoco_menagerie": Repository(
         url="https://github.com/deepmind/mujoco_menagerie.git",
-        commit="a88bc450470d97ebc1f282e5969675fb4d1f0ed7",
+        commit="dec370da8895f4a04c20bae57a52f3bd16148ee6",
         cache_path="mujoco_menagerie",
     ),
     "nao_robot": Repository(

--- a/robot_descriptions/robotiq_2f85_v4_mj_description.py
+++ b/robot_descriptions/robotiq_2f85_v4_mj_description.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Stéphane Caron
+
+"""Robotiq 2F-85 MJCF description."""
+
+from os import getenv as _getenv
+from os import path as _path
+
+from ._cache import clone_to_cache as _clone_to_cache
+
+REPOSITORY_PATH: str = _clone_to_cache(
+    "mujoco_menagerie",
+    commit=_getenv("ROBOT_DESCRIPTION_COMMIT", None),
+)
+
+PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "robotiq_2f85_v4")
+
+MJCF_PATH: str = _path.join(PACKAGE_PATH, "2f85.xml")


### PR DESCRIPTION
This pull request accomplishes the following:

1. Updates the commit hash for the mujoco_menagerie library to the latest
2. Adds the [robotiq_2f85_v4](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotiq_2f85_v4) model