### PR TITLE
Add example with the Candlewick visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Description: BXI Elf2 (URDF)
 - Example: Load all humanoid robot descriptions
 - Example: Load all quadruped robot descriptions
+- Example: Show any robot description in the Candlewick viewer
 - Export `DESCRIPTIONS` dictionary from top-level module
 
 ### Changed

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 ## Show all humanoid descriptions
 
+This example shows all humanoid robot descriptions using Pinocchio and MeshCat:
+
 ```
 python all_humanoids.py
 ```
@@ -9,6 +11,8 @@ python all_humanoids.py
 ![image](https://github.com/user-attachments/assets/cc3cc4e9-622e-4cc5-b7d1-5a01d22cb827)
 
 ## Show all quadruped descriptions
+
+This example shows all quadruped robot descriptions using Pinocchio and MeshCat:
 
 ```
 python all_quadrupeds.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# Examples
+
+## Show all humanoid descriptions
+
+```
+python all_humanoids.py
+```
+
+![image](https://github.com/user-attachments/assets/cc3cc4e9-622e-4cc5-b7d1-5a01d22cb827)
+
+## Show all quadruped descriptions
+
+```
+python all_quadrupeds.py
+```
+
+![image](https://github.com/user-attachments/assets/0de682e5-8b8e-4c9d-856c-386c1aa6214a)

--- a/examples/load_in_idyntree.py
+++ b/examples/load_in_idyntree.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Giulio Romualdi
 
 """
-Load a robot description, specified from the command line, in iDynTree.
+Load a robot description selected from the command line in iDynTree.
 
 This example requires iDynTree, which can be installed by
 `conda install -c conda-forge idyntree`.

--- a/examples/load_in_mujoco.py
+++ b/examples/load_in_mujoco.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Show a robot description, specified from the command line, in MuJoCo.
+Load a robot description selected from the command line in MuJoCo.
 
 This example requires MuJoCo, which is installed by `pip install mujoco`.
 """

--- a/examples/load_in_pinocchio.py
+++ b/examples/load_in_pinocchio.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Load a robot description, specified from the command line, in Pinocchio.
+Load a robot description selected from the command line in Pinocchio.
 
 This example requires Pinocchio, installed by e.g. `conda install pinocchio`.
 """

--- a/examples/load_in_pybullet.py
+++ b/examples/load_in_pybullet.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Load a robot description, specified from the command line, in PyBullet.
+Load a robot description selected from the command line in PyBullet.
 
 This example requires PyBullet, which is installed by `pip install pybullet`.
 """

--- a/examples/load_in_robomeshcat.py
+++ b/examples/load_in_robomeshcat.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Load a robot description, specified from the command line, in RoboMeshCat.
+Load a robot description selected from the command line in RoboMeshCat.
 
 This example uses RoboMeshCat: https://github.com/petrikvladimir/RoboMeshCat
 """

--- a/examples/load_in_yourdfpy.py
+++ b/examples/load_in_yourdfpy.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Load a robot description, specified from the command line, using yourdfpy.
+Load a robot description selected from the command line in yourdfpy.
 
 This example requires yourdfpy, which is installed by `pip install yourdfpy`.
 """

--- a/examples/show_in_candlewick.py
+++ b/examples/show_in_candlewick.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Inria
+
+"""
+Show a robot description selected from the command line in Candlewick.
+
+This example requires Pinocchio, installed by e.g. `conda install pinocchio`,
+and Candlewick: https://github.com/Simple-Robotics/candlewick.
+"""
+
+import argparse
+
+try:
+    from candlewick.multibody import Visualizer, VisualizerConfig
+except ImportError as import_error:
+    raise ImportError(
+        "Candlewick not found, "
+        "see https://github.com/Simple-Robotics/candlewick"
+    ) from import_error
+
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("name", help="name of the robot description")
+    parser.add_argument("--width", help="window width in px", default=1600)
+    parser.add_argument("--height", help="window height in px", default=900)
+    args = parser.parse_args()
+
+    try:
+        robot = load_robot_description(args.name)
+    except ModuleNotFoundError:
+        robot = load_robot_description(f"{args.name}_description")
+
+    config = VisualizerConfig()
+    config.width = args.width
+    config.height = args.height
+    visualizer = Visualizer(config, robot.model, robot.visual_model)
+    while not visualizer.shouldExit:
+        visualizer.display(robot.q0)

--- a/examples/show_in_meshcat.py
+++ b/examples/show_in_meshcat.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Show a robot descriptions, specified from the command line, using MeshCat.
+Show a robot description selected from the command line using MeshCat.
 
 This example is equivalent to `python -m robot_descriptions show_in_meshcat`.
 It requires Pinocchio, installed by e.g. `conda install pinocchio`, and

--- a/examples/show_in_mujoco.py
+++ b/examples/show_in_mujoco.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Show a robot description, specified from the command line, using MuJoCo.
+Show a robot description selected from the command line using MuJoCo.
 
 This example is equivalent to `python -m robot_descriptions show_in_mujoco`. It
 requires MuJoCo, which is installed by `pip install mujoco`, and the MuJoCo

--- a/examples/show_in_pybullet.py
+++ b/examples/show_in_pybullet.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Show a robot description, specified from the command line, using PyBullet.
+Show a robot description selected from the command line using PyBullet.
 
 This example is equivalent to `python -m robot_descriptions show_in_pybullet`.
 It requires PyBullet, which can be installed by `pip install pybullet`.

--- a/examples/show_in_robomeshcat.py
+++ b/examples/show_in_robomeshcat.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Load a robot description, specified from the command line, in RoboMeshCat.
+Load a robot description selected from the command line in RoboMeshCat.
 
 This example uses RoboMeshCat: https://github.com/petrikvladimir/RoboMeshCat
 """

--- a/examples/show_in_yourdfpy.py
+++ b/examples/show_in_yourdfpy.py
@@ -5,7 +5,7 @@
 # Copyright 2022 Stéphane Caron
 
 """
-Show a robot description, specified from the command line, using yourdfpy.
+Show a robot description selected from the command line in yourdfpy.
 
 This example is equivalent to `python -m robot_descriptions show_in_yourdfpy`.
 It requires `yourdfpy`, an optional dependency that can be installed by `pip


### PR DESCRIPTION
This PR adds a visualization example using [Candlewick](https://github.com/Simple-Robotics/candlewick), a renderer (based on SDL_gpu) for robot descriptions loaded in [Pinocchio](https://github.com/stack-of-tasks/pinocchio/):

```console
python show_in_candlewick.py spot_mj
```

![image](https://github.com/user-attachments/assets/b87a13b2-87c6-4c62-b3fb-40d414860310)
