### PR TITLE
Update ergocub models to latest ergocub-software version (v0.7.7) and latest ergoCub model (ergoCubSN002)

### DIFF
--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -111,7 +111,7 @@ REPOSITORIES: Dict[str, Repository] = {
     ),
     "ergocub-software": Repository(
         url="https://github.com/icub-tech-iit/ergocub-software.git",
-        commit="ac3f223dc2f183dea3f819369da0d58b59f1b2d3",
+        commit="v0.7.7",
         cache_path="ergocub-software",
     ),
     "example-robot-data": Repository(

--- a/robot_descriptions/ergocub_description.py
+++ b/robot_descriptions/ergocub_description.py
@@ -19,5 +19,5 @@ REPOSITORY_PATH: str = _clone_to_cache(
 PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "urdf", "ergoCub")
 
 URDF_PATH: str = _path.join(
-    PACKAGE_PATH, "robots", "ergoCubSN000", "model.urdf"
+    PACKAGE_PATH, "robots", "ergoCubSN002", "model.urdf"
 )


### PR DESCRIPTION
This PR updates the version of ergoCub model contained in `robot_descriptions.py` in two ways:
* Bumps the tag of ergocub-software (the repo that hosts the ergocub URDF models) to the latest tag https://github.com/icub-tech-iit/ergocub-software/releases/tag/v0.7.7 (if you prefer to use the corresponding commit to avoid tag invalidation, I can also do that).
* Change the model of ergoCub used from `ergoCubSN000` (the first revision of the robot) to `ergoCubSN002` (the latest one).

If you are a user interested in the latest and more close to the ergoCub reality model I always suggest to refer to https://github.com/icub-tech-iit/ergocub-software/, but this PR at least make sure that `robot_descriptions.py` users will not get a critically outdated ergoCub URDF model, thanks!


fyi @GiulioRomualdi @NicoGene @hany606