### PR TITLE
Update Piper MJCF path and Update MuJoCo Menagerie Commit Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Description: Fourier N1 (URDF)
 - Description: YAM (MJCF) (thanks to @kevinzakka)
 
+### Changed
+
+- Update `piper_mj_description` to load `piper.xml` instead of `scene.xml`
+
 ## [1.17.0] - 2025-05-08
 
 ### Added

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -177,7 +177,7 @@ REPOSITORIES: Dict[str, Repository] = {
     ),
     "mujoco_menagerie": Repository(
         url="https://github.com/deepmind/mujoco_menagerie.git",
-        commit="4a7015530bd7a4161103ae8f0905a96481e4cc1a",
+        commit="f3475402a11acf5ba767a8bec03cc9bea9819d8d",
         cache_path="mujoco_menagerie",
     ),
     "nao_robot": Repository(

--- a/robot_descriptions/piper_mj_description.py
+++ b/robot_descriptions/piper_mj_description.py
@@ -18,4 +18,4 @@ REPOSITORY_PATH: str = _clone_to_cache(
 
 PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "agilex_piper")
 
-MJCF_PATH: str = _path.join(PACKAGE_PATH, "scene.xml")
+MJCF_PATH: str = _path.join(PACKAGE_PATH, "piper.xml")


### PR DESCRIPTION
Hi,

This PR updates the Piper MJCF path to use `piper.xml` instead of `scene.xml`. This matches the convention used by other robot arms in this project, which load only the arm with the MJCF path instead of the `scene.xml`. I also updated the MuJoCo Menagerie Commit Hash to the latest version 🚀