### PR TITLE
Allow passing `kwargs` to `yourdfpy.load_robot_description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Update `piper_mj_description` to load `piper.xml` instead of `scene.xml` (thanks to @jonzamora)
+- Allow passing `kwargs` to `yourdfpy.load_robot_description` (thanks to @sea-bass)
 
 ## [1.17.0] - 2025-05-08
 

--- a/robot_descriptions/loaders/yourdfpy.py
+++ b/robot_descriptions/loaders/yourdfpy.py
@@ -23,8 +23,7 @@ except ModuleNotFoundError as e:
 def load_robot_description(
     description_name: str,
     commit: Optional[str] = None,
-    load_visuals: bool = True,
-    load_collisions: bool = True,
+    **kwargs,
 ) -> yourdfpy.URDF:
     """Load a robot description in yourdfpy.
 
@@ -32,8 +31,11 @@ def load_robot_description(
         description_name: Name of the robot description.
         commit: If specified, check out that commit from the cloned robot
             description repository.
-        load_visuals: If true, loads the visual meshes and scene.
-        load_collisions: If true, loads the collision meshes and scene.
+        kwargs: arguments passed to yourdfpy.URDF.load function, including:
+            build_scene_graph: Whether to build a scene graph from visual elements.
+            build_collision_scene_graph: Whether to build a scene graph from collision elements.
+            load_meshes: Whether to load the meshes for the visual elements.
+            load_collision_meshes: Whether to load the meshes for the collision elements.
 
     Returns:
         Robot model for yourdfpy.
@@ -49,8 +51,5 @@ def load_robot_description(
     return yourdfpy.URDF.load(
         module.URDF_PATH,
         mesh_dir=module.PACKAGE_PATH,
-        build_scene_graph=load_visuals,
-        build_collision_scene_graph=load_collisions,
-        load_meshes=load_visuals,
-        load_collision_meshes=load_collisions,
+        **kwargs,
     )

--- a/robot_descriptions/loaders/yourdfpy.py
+++ b/robot_descriptions/loaders/yourdfpy.py
@@ -23,6 +23,8 @@ except ModuleNotFoundError as e:
 def load_robot_description(
     description_name: str,
     commit: Optional[str] = None,
+    load_visuals: bool = True,
+    load_collisions: bool = True,
 ) -> yourdfpy.URDF:
     """Load a robot description in yourdfpy.
 
@@ -30,6 +32,8 @@ def load_robot_description(
         description_name: Name of the robot description.
         commit: If specified, check out that commit from the cloned robot
             description repository.
+        load_visuals: If true, loads the visual meshes and scene.
+        load_collisions: If true, loads the collision meshes and scene.
 
     Returns:
         Robot model for yourdfpy.
@@ -42,4 +46,11 @@ def load_robot_description(
     if not hasattr(module, "URDF_PATH"):
         raise ValueError(f"{description_name} is not a URDF description")
 
-    return yourdfpy.URDF.load(module.URDF_PATH, mesh_dir=module.PACKAGE_PATH)
+    return yourdfpy.URDF.load(
+        module.URDF_PATH,
+        mesh_dir=module.PACKAGE_PATH,
+        build_scene_graph=load_visuals,
+        build_collision_scene_graph=load_collisions,
+        load_meshes=load_visuals,
+        load_collision_meshes=load_collisions,
+    )


### PR DESCRIPTION
Created a small update to help solve this issue in Viser: https://github.com/nerfstudio-project/viser/issues/483

Otherwise, the `yourdfpy` loader in this package only ever loads visual meshes/scenes, but not the collision ones.

I did default both parameters to true since it shouldn't hurt to always load everything by default, but let me know if this is not desired.