### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.21.0] - 2025-09-03
+
 ### Added
 
+- Add "with hands" variant to the G1 MJCF description (thanks to @jonzamora)
 - Description: TIAGo++ (MJCF) (thanks to @Danfoa)
 - Description: ToddlerBot (URDF)
 - Description: Unitree H1\_2 (MJCF) (thanks to @TonyZYT2000)
@@ -14,11 +17,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - CICD: Disable fail-fast when testing loaders
-- Update `g1_mj_description` to load `g1_with_hands.xml` instead of `g1.xml`
-
-### Fixed
-
-- Update commit and URDF path of YAM description
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,6 +32,8 @@ authors:
 - family-names: "Traversaro"
   given-names: "Silvio"
   orcid: "https://orcid.org/0000-0002-9283-6133"
+- family-names: "Zamora"
+  given-names: "Jonathan"
 - family-names: "Castro"
   given-names: "Sebastian"
   orcid: "https://orcid.org/0000-0001-5754-9959"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,3 +42,5 @@ authors:
 - family-names: "Jallet"
   given-names: "Wilson"
   orcid: "https://orcid.org/0000-0001-8222-2739"
+- family-names: "Zhang"
+  given-names: "Yutong"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "robot_descriptions.py: Robot descriptions in Python"
-version: 1.20.0
-date-released: 2025-07-15
+version: 1.21.0
+date-released: 2025-09-03
 url: "https://github.com/robot-descriptions/robot_descriptions.py"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ If you use this project in your works, please cite as follows:
 ```bibtex
 @software{robot_descriptions_py,
   title = {{robot_descriptions.py: Robot descriptions in Python}},
-  author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong},
+  author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
   version = {1.21.0},

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ If you use this project in your works, please cite as follows:
   author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
-  version = {1.20.0},
+  version = {1.21.0},
   year = {2025}
 }
 ```

--- a/robot_descriptions/__init__.py
+++ b/robot_descriptions/__init__.py
@@ -8,6 +8,6 @@
 
 from ._descriptions import DESCRIPTIONS
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"
 
 __all__ = ["DESCRIPTIONS"]


### PR DESCRIPTION
This release adds 4 robot descriptions and 1 description variant contributed by @Danfoa, @jonzamora and @TonyZYT2000 :+1:

### Added

- Add "with hands" variant to the G1 MJCF description (thanks to @jonzamora)
- Description: TIAGo++ (MJCF) (thanks to @Danfoa)
- Description: ToddlerBot (URDF)
- Description: Unitree H1\_2 (MJCF) (thanks to @TonyZYT2000)
- Description: Unitree H1\_2 (URDF) (thanks to @TonyZYT2000)

### Changed

- CICD: Disable fail-fast when testing loaders

### Fixed

- Update commit and URDF path of YAM description