### PR TITLE
Update Unitree G1 MJCF path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - CICD: Disable fail-fast when testing loaders
+- Update `g1_mj_description` to load `g1_with_hands.xml` instead of `g1.xml`
 
 ## [1.20.0] - 2025-07-15
 

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -205,7 +205,7 @@ REPOSITORIES: Dict[str, Repository] = {
     ),
     "mujoco_menagerie": Repository(
         url="https://github.com/deepmind/mujoco_menagerie.git",
-        commit="66384c6b8581c811a7b1eb63bcf4fa944fa43602",
+        commit="c1503a62496b64222c64ff65dd652d461a5b064e",
         cache_path="mujoco_menagerie",
     ),
     "nao_robot": Repository(

--- a/robot_descriptions/g1_mj_description.py
+++ b/robot_descriptions/g1_mj_description.py
@@ -18,4 +18,6 @@ REPOSITORY_PATH: str = _clone_to_cache(
 
 PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "unitree_g1")
 
-MJCF_PATH: str = _path.join(PACKAGE_PATH, "g1_with_hands.xml")
+MJCF_PATH: str = _path.join(PACKAGE_PATH, "g1.xml")
+
+MJCF_PATH_WITH_HANDS: str = _path.join(PACKAGE_PATH, "g1_with_hands.xml")

--- a/robot_descriptions/g1_mj_description.py
+++ b/robot_descriptions/g1_mj_description.py
@@ -18,4 +18,4 @@ REPOSITORY_PATH: str = _clone_to_cache(
 
 PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "unitree_g1")
 
-MJCF_PATH: str = _path.join(PACKAGE_PATH, "g1.xml")
+MJCF_PATH: str = _path.join(PACKAGE_PATH, "g1_with_hands.xml")


### PR DESCRIPTION
Hi,

This PR updates the MJCF path of the Unitree G1 robot from `g1.xml` to `g1_with_hands.xml`.

The purpose is so users can interact directly with the G1 and its supported 3-finger hands, which is an important use-case for the G1 (e.g. for manipulation tasks).

Besides this, the `g1.xml` has "rubber hands" that have no collisions, so they aren't useful for manipulation tasks at this time.