### PR TITLE
Update commit and URDF path of YAM description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - CICD: Disable fail-fast when testing loaders
 
+### Fixed
+
+- Update commit and URDF path of YAM description
+
 ## [1.20.0] - 2025-07-15
 
 ### Added

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -152,7 +152,7 @@ REPOSITORIES: Dict[str, Repository] = {
     ),
     "i2rt": Repository(
         url="https://github.com/i2rt-robotics/i2rt.git",
-        commit="8a8f804d72b41a04a5c69520031aec9a5d328104",
+        commit="7809b5b17227162d265f922e2e10598c0e214322",
         cache_path="i2rt",
     ),
     "icub-models": Repository(

--- a/robot_descriptions/yam_description.py
+++ b/robot_descriptions/yam_description.py
@@ -16,6 +16,6 @@ REPOSITORY_PATH: str = _clone_to_cache(
     commit=_getenv("ROBOT_DESCRIPTION_COMMIT", None),
 )
 
-PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "robot_models/yam/assets")
+PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "i2rt", "robot_models", "yam")
 
-URDF_PATH: str = _path.join(REPOSITORY_PATH, "robot_models/yam/yam.urdf")
+URDF_PATH: str = _path.join(PACKAGE_PATH, "yam.urdf")


### PR DESCRIPTION
It seems the commit history of the corresponding repository was rewritten.