### PR TITLE
Make compiled descriptions relocatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Xacro: Generated URDFs now emit relocatable `package://` asset URIs instead of absolute paths (thanks to @nickswalker)
+- Bump `xacrodoc` dependency to `>=2.0.0`
+
+
 ## [3.1.0] - 2026-07-11
 
 ### Added

--- a/pixi.lock
+++ b/pixi.lock
@@ -7324,7 +7324,7 @@ packages:
   - pin>=2.6.10 ; extra == 'opts'
   - pybullet>=3.2.6 ; extra == 'opts'
   - robomeshcat>=1.0.4 ; extra == 'opts'
-  - xacrodoc>=1.1.1 ; extra == 'opts'
+  - xacrodoc>=2.0.0 ; extra == 'opts'
   - yourdfpy>=0.0.56 ; extra == 'opts'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ opts = [
     "pin >=2.6.10",
     "pybullet >=3.2.6",
     "robomeshcat >=1.0.4",
-    "xacrodoc >=1.1.1",
+    "xacrodoc >=2.0.0",
     "yourdfpy >=0.0.56",
 ]
 

--- a/robot_descriptions/_package_dirs.py
+++ b/robot_descriptions/_package_dirs.py
@@ -4,9 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os.path
+import re
 from typing import List
 
-from ._xacro import get_urdf_path
+from ._xacro import _map_filename_attrs, get_urdf_path
+
+_PACKAGE_URI_RE = re.compile(r"package://([^/]+)/(.*)")
 
 
 def get_package_dirs(module) -> List[str]:
@@ -24,8 +27,39 @@ def get_package_dirs(module) -> List[str]:
         os.path.dirname(module.PACKAGE_PATH),
         os.path.dirname(module.REPOSITORY_PATH),
     ]
+    for package_path in getattr(module, "XACRO_PACKAGE_PATHS", {}).values():
+        # These packages can live in a separately cloned repository whose
+        # directory name differs from the ROS package name
+        package_dirs.append(os.path.dirname(package_path))
     if hasattr(module, "URDF_PATH") or hasattr(module, "XACRO_PATH"):
         package_dirs.append(
             os.path.dirname(get_urdf_path(module))  # e.g. laikago_description
         )
     return package_dirs
+
+
+def resolve_package_uris(urdf_string: str, package_dirs: List[str]) -> str:
+    """Rewrite resolvable ``package://`` asset URIs to absolute file paths.
+
+    Args:
+        urdf_string: Serialized URDF XML.
+        package_dirs: Candidate package directories, as returned by
+            :func:`get_package_dirs`.
+
+    Returns:
+        URDF XML with resolvable ``package://`` URIs replaced by absolute
+        paths; unresolvable references are left unchanged.
+    """
+
+    def resolve_one(uri: str) -> str:
+        match = _PACKAGE_URI_RE.match(uri)
+        if match is None:
+            return uri
+        package_name, rel_path = match.group(1), match.group(2)
+        for package_dir in package_dirs:
+            candidate = os.path.join(package_dir, package_name, rel_path)
+            if os.path.exists(candidate):
+                return candidate
+        return uri
+
+    return _map_filename_attrs(urdf_string, resolve_one)

--- a/robot_descriptions/_xacro.py
+++ b/robot_descriptions/_xacro.py
@@ -8,11 +8,13 @@
 import hashlib
 import json
 import os
+import re
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 from ._cache import get_head_sha
 
@@ -107,6 +109,83 @@ def _pushd(path: str):
         os.chdir(cwd)
 
 
+def _to_package_uri(
+    filename: str,
+    *,
+    package_name: str,
+    repo_path: str,
+    package_path: str,
+    package_uri_root: str,
+) -> str:
+    """Convert a repo-local file URI to a package URI.
+
+    Args:
+        filename: Filename from a generated URDF.
+        package_name: Name to use in the rewritten package URI.
+        repo_path: Root path of the cloned description repository.
+        package_path: Package path exported by the description module.
+        package_uri_root: Root path to strip when forming the package URI.
+
+    Returns:
+        Original filename if no rewrite applies, otherwise a package URI.
+    """
+    if not filename.startswith("file://"):
+        return filename
+
+    parsed = urlparse(filename)
+    if parsed.netloc not in ("", "localhost"):
+        return filename
+
+    abs_path = os.path.normpath(unquote(parsed.path))
+    if abs_path == package_uri_root or abs_path.startswith(
+        package_uri_root + os.sep
+    ):
+        rel_path = os.path.relpath(abs_path, package_uri_root)
+        return f"package://{package_name}/{rel_path}"
+    if abs_path == repo_path or abs_path.startswith(repo_path + os.sep):
+        rel_path = os.path.relpath(abs_path, repo_path)
+        return f"package://{package_name}/{rel_path}"
+    if abs_path == package_path or abs_path.startswith(package_path + os.sep):
+        rel_path = os.path.relpath(abs_path, package_path)
+        return f"package://{package_name}/{rel_path}"
+    return filename
+
+
+def _convert_filenames_to_package_uris(module: Any, urdf_string: str) -> str:
+    """Rewrite repo-local file URIs in a URDF string to package URIs.
+
+    Args:
+        module: Robot description module providing path metadata.
+        urdf_string: Serialized URDF XML.
+
+    Returns:
+        URDF XML with repo-local file URIs rewritten to package URIs.
+    """
+    package_name = os.path.basename(os.path.normpath(module.REPOSITORY_PATH))
+    repo_path = os.path.normpath(module.REPOSITORY_PATH)
+    package_path = os.path.normpath(module.PACKAGE_PATH)
+    # By default, asset paths are made relative to PACKAGE_PATH. Nested
+    # package layouts can override this with PACKAGE_URI_ROOT.
+    package_uri_root = os.path.normpath(
+        getattr(module, "PACKAGE_URI_ROOT", package_path)
+    )
+
+    def rewrite(match: re.Match[str]) -> str:
+        prefix = match.group(1)
+        quote = match.group(2)
+        filename = match.group(3)
+        new_filename = _to_package_uri(
+            filename,
+            package_name=package_name,
+            repo_path=repo_path,
+            package_path=package_path,
+            package_uri_root=package_uri_root,
+        )
+        return f"{prefix}{quote}{new_filename}{quote}"
+
+    return re.sub(r"(\bfilename\s*=\s*)(['\"])(.*?)\2", rewrite, urdf_string)
+
+
 def _generate_xacro_output_path(
     module: Any,
     xacrodoc_module: Any,
@@ -155,29 +234,11 @@ def _generate_xacro_output_path(
         doc = xacrodoc_module.XacroDoc.from_file(
             xacro_path,
             subargs=xacro_args,
+            # Preserve file/relative paths from the generated URDF so we can
+            # normalize them to a relocatable package URI later.
+            resolve_packages=False,
         )
-    # We're resolving relative paths manually here, as xacrodoc
-    # only handles package resolution. xacrodoc has a private
-    # helper which would at least make this cleaner,
-    # _urdf_elements_with_filenames, but we'll wait for a
-    # public interface.
-
-    for tag_name in ("mesh", "material"):
-        for elem in doc.dom.getElementsByTagName(tag_name):
-            if not elem.hasAttribute("filename"):
-                continue
-            filename = elem.getAttribute("filename")
-            rel_path = None
-            if filename.startswith("file://./"):
-                rel_path = filename[len("file://./") :]
-            elif filename.startswith("./"):
-                rel_path = filename[2:]
-            if rel_path is not None:
-                abs_path = os.path.abspath(
-                    os.path.join(module.PACKAGE_PATH, rel_path)
-                )
-                elem.setAttribute("filename", abs_path)
-
+    doc.rootdir = module.PACKAGE_PATH
     tmp_file = tempfile.NamedTemporaryFile(
         prefix=f"{description_name}-",
         suffix=f".{output_format}",
@@ -186,7 +247,17 @@ def _generate_xacro_output_path(
     )
     tmp_file.close()
     try:
-        doc.to_urdf_file(tmp_file.name)
+        # First DOM rewrite: make all plain filenames
+        # into filename:// absolute paths.
+        urdf_string = doc.to_urdf_string(
+            use_protocols=True,
+            pretty=True,
+        )
+        # Second DOM rewrite: convert filename:///absolute/paths to
+        # be package:// paths from the base of the cache.
+        urdf_string = _convert_filenames_to_package_uris(module, urdf_string)
+        with open(tmp_file.name, "w", encoding="utf-8") as urdf_file:
+            urdf_file.write(urdf_string)
         os.replace(tmp_file.name, output_path)
     finally:
         if os.path.exists(tmp_file.name):

--- a/robot_descriptions/_xacro.py
+++ b/robot_descriptions/_xacro.py
@@ -109,25 +109,46 @@ def _pushd(path: str):
         os.chdir(cwd)
 
 
-def _to_package_uri(
-    filename: str,
-    *,
-    package_name: str,
-    repo_path: str,
-    package_path: str,
-    package_uri_root: str,
-) -> str:
-    """Convert a repo-local file URI to a package URI.
+_FILENAME_ATTR_RE = re.compile(r"(\bfilename\s*=\s*)(['\"])(.*?)\2")
+
+
+def _map_filename_attrs(urdf_string: str, transform) -> str:
+    """Rewrite each ``filename="..."`` attribute value via a transform.
 
     Args:
-        filename: Filename from a generated URDF.
-        package_name: Name to use in the rewritten package URI.
-        repo_path: Root path of the cloned description repository.
-        package_path: Package path exported by the description module.
-        package_uri_root: Root path to strip when forming the package URI.
+        urdf_string: Serialized URDF XML.
+        transform: Callable mapping a filename value to its replacement.
 
     Returns:
-        Original filename if no rewrite applies, otherwise a package URI.
+        URDF XML with each filename attribute rewritten.
+    """
+
+    def rewrite(match: re.Match[str]) -> str:
+        prefix, quote, filename = match.groups()
+        return f"{prefix}{quote}{transform(filename)}{quote}"
+
+    return _FILENAME_ATTR_RE.sub(rewrite, urdf_string)
+
+
+def _to_package_uri(
+    filename: str, *, package_name: str, package_path: str
+) -> str:
+    """Rewrite a ``file://`` URI pointing inside the package to a package URI.
+
+    A ``file://`` reference to a file under ``package_path`` becomes
+    ``package://<package_name>/<path relative to package_path>``. Anything
+    else -- a non-``file`` URI, a remote host, or a path outside the package
+    -- is returned unchanged.
+
+    Args:
+        filename: Filename attribute value from a generated URDF.
+        package_name: Package name to use in the URI, i.e. the basename of
+            ``package_path``.
+        package_path: Absolute path to the package root.
+
+    Returns:
+        The rewritten ``package://`` URI, or ``filename`` unchanged when no
+        rewrite applies.
     """
     if not filename.startswith("file://"):
         return filename
@@ -137,14 +158,6 @@ def _to_package_uri(
         return filename
 
     abs_path = os.path.normpath(unquote(parsed.path))
-    if abs_path == package_uri_root or abs_path.startswith(
-        package_uri_root + os.sep
-    ):
-        rel_path = os.path.relpath(abs_path, package_uri_root)
-        return f"package://{package_name}/{rel_path}"
-    if abs_path == repo_path or abs_path.startswith(repo_path + os.sep):
-        rel_path = os.path.relpath(abs_path, repo_path)
-        return f"package://{package_name}/{rel_path}"
     if abs_path == package_path or abs_path.startswith(package_path + os.sep):
         rel_path = os.path.relpath(abs_path, package_path)
         return f"package://{package_name}/{rel_path}"
@@ -152,38 +165,26 @@ def _to_package_uri(
 
 
 def _convert_filenames_to_package_uris(module: Any, urdf_string: str) -> str:
-    """Rewrite repo-local file URIs in a URDF string to package URIs.
+    """Rewrite package-local file URIs in a URDF string to package URIs.
 
     Args:
         module: Robot description module providing path metadata.
         urdf_string: Serialized URDF XML.
 
     Returns:
-        URDF XML with repo-local file URIs rewritten to package URIs.
+        URDF XML with package-local file URIs rewritten to package URIs.
     """
-    package_name = os.path.basename(os.path.normpath(module.REPOSITORY_PATH))
-    repo_path = os.path.normpath(module.REPOSITORY_PATH)
     package_path = os.path.normpath(module.PACKAGE_PATH)
-    # By default, asset paths are made relative to PACKAGE_PATH. Nested
-    # package layouts can override this with PACKAGE_URI_ROOT.
-    package_uri_root = os.path.normpath(
-        getattr(module, "PACKAGE_URI_ROOT", package_path)
-    )
+    package_name = os.path.basename(package_path)
 
-    def rewrite(match: re.Match[str]) -> str:
-        prefix = match.group(1)
-        quote = match.group(2)
-        filename = match.group(3)
-        new_filename = _to_package_uri(
+    return _map_filename_attrs(
+        urdf_string,
+        lambda filename: _to_package_uri(
             filename,
             package_name=package_name,
-            repo_path=repo_path,
             package_path=package_path,
-            package_uri_root=package_uri_root,
-        )
-        return f"{prefix}{quote}{new_filename}{quote}"
-
-    return re.sub(r"(\bfilename\s*=\s*)(['\"])(.*?)\2", rewrite, urdf_string)
+        ),
+    )
 
 
 def _generate_xacro_output_path(
@@ -247,14 +248,14 @@ def _generate_xacro_output_path(
     )
     tmp_file.close()
     try:
-        # First DOM rewrite: make all plain filenames
-        # into filename:// absolute paths.
+        # Serialize with protocol prefixes so local asset paths become
+        # absolute file:// URIs (package:// references are kept as-is).
         urdf_string = doc.to_urdf_string(
             use_protocols=True,
             pretty=True,
         )
-        # Second DOM rewrite: convert filename:///absolute/paths to
-        # be package:// paths from the base of the cache.
+        # Rewrite those file:// URIs to package:// URIs relative to the
+        # package, so the cached URDF is relocatable.
         urdf_string = _convert_filenames_to_package_uris(module, urdf_string)
         with open(tmp_file.name, "w", encoding="utf-8") as urdf_file:
             urdf_file.write(urdf_string)

--- a/robot_descriptions/loaders/pybullet.py
+++ b/robot_descriptions/loaders/pybullet.py
@@ -6,11 +6,13 @@
 """Load a robot description in PyBullet."""
 
 import os
+import tempfile
 from importlib import import_module  # type: ignore
 from typing import Optional
 
 import pybullet
 
+from .._package_dirs import get_package_dirs, resolve_package_uris
 from .._xacro import get_urdf_path
 
 
@@ -51,5 +53,30 @@ def load_robot_description(
     urdf_path = get_urdf_path(module, xacro_args=xacro_args)
 
     pybullet.setAdditionalSearchPath(module.PACKAGE_PATH)
-    robot = pybullet.loadURDF(urdf_path, **kwargs)
+
+    # PyBullet resolves package:// URIs by walking up from the URDF file
+    # location rather than from a set of package directories. This fails for
+    # relocatable URDFs cached away from their assets, so we resolve those URIs
+    # to absolute paths first. The resolved copy is written next to the source
+    # URDF to keep any remaining relative paths valid.
+    with open(urdf_path, encoding="utf-8") as urdf_file:
+        urdf_string = urdf_file.read()
+    resolved_string = resolve_package_uris(
+        urdf_string, get_package_dirs(module)
+    )
+    if resolved_string == urdf_string:
+        return pybullet.loadURDF(urdf_path, **kwargs)
+
+    resolved_file = tempfile.NamedTemporaryFile(
+        prefix=f"{description_name}-",
+        suffix=".urdf",
+        dir=os.path.dirname(urdf_path),
+        delete=False,
+    )
+    try:
+        resolved_file.write(resolved_string.encode("utf-8"))
+        resolved_file.close()
+        robot = pybullet.loadURDF(resolved_file.name, **kwargs)
+    finally:
+        os.unlink(resolved_file.name)
     return robot

--- a/tests/loaders/test_pybullet.py
+++ b/tests/loaders/test_pybullet.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import tempfile
 import types
 import unittest
 from unittest.mock import patch
@@ -50,9 +52,16 @@ class TestPyBullet(unittest.TestCase):
         _set_search_path_mock,
         _load_urdf_mock,
     ):
+        urdf_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".urdf", delete=False
+        )
+        urdf_file.write("<robot name='test'/>")  # no package:// to resolve
+        urdf_file.close()
+        self.addCleanup(os.unlink, urdf_file.name)
         module = types.SimpleNamespace(
-            URDF_PATH="/tmp/test.urdf",
+            URDF_PATH=urdf_file.name,
             PACKAGE_PATH="/tmp/pkg",
+            REPOSITORY_PATH="/tmp/repo",
         )
         import_module_mock.return_value = module
         get_urdf_path_mock.return_value = module.URDF_PATH

--- a/tests/test_xacro.py
+++ b/tests/test_xacro.py
@@ -13,6 +13,8 @@ from unittest.mock import patch
 from robot_descriptions._descriptions import DESCRIPTION_FORMATS
 from robot_descriptions._xacro import (
     _DESCRIPTION_FORMAT_ATTRS,
+    _convert_filenames_to_package_uris,
+    _to_package_uri,
     get_description_path,
     get_mjcf_path,
     get_srdf_path,
@@ -21,16 +23,11 @@ from robot_descriptions._xacro import (
 
 
 class _FakeDoc:
-    class _Dom:
-        @staticmethod
-        def getElementsByTagName(_name: str):
-            return []
+    rootdir = None
 
-    dom = _Dom()
-
-    def to_urdf_file(self, path: str) -> None:
-        with open(path, "w", encoding="utf-8") as out_file:
-            out_file.write("<robot name='generated'/>")
+    @staticmethod
+    def to_urdf_string(use_protocols: bool, pretty: bool) -> str:
+        return "<robot name='generated'/>"
 
 
 class TestXacro(unittest.TestCase):
@@ -130,10 +127,11 @@ class TestXacro(unittest.TestCase):
 
         class FakeXacroDoc:
             @staticmethod
-            def from_file(path: str, subargs):
+            def from_file(path: str, subargs, resolve_packages=False):
                 calls["from_file"] += 1
                 self.assertEqual(path, xacro_path)
                 self.assertEqual(subargs, {"prefix": "test_"})
+                self.assertFalse(resolve_packages)
                 return _FakeDoc()
 
         fake_xacrodoc = types.SimpleNamespace(
@@ -171,8 +169,9 @@ class TestXacro(unittest.TestCase):
 
         class FakeXacroDoc:
             @staticmethod
-            def from_file(path: str, subargs):
+            def from_file(path: str, subargs, resolve_packages=False):
                 self.assertEqual(path, xacro_path)
+                self.assertFalse(resolve_packages)
                 calls["subargs"].append(subargs)
                 return _FakeDoc()
 
@@ -215,3 +214,79 @@ class TestXacro(unittest.TestCase):
         )
         self.assertEqual(first_path, second_path)
         self.assertNotEqual(first_path, third_path)
+
+    def test_to_package_uri(self):
+        package_dir = "/tmp/ros2_kortex/kortex_description"
+        mesh = os.path.join(package_dir, "meshes", "base_link.STL")
+        outside = os.path.join("/tmp/ros2_kortex", "other", "thing.stl")
+
+        cases = [
+            (
+                f"file://{mesh}",
+                "package://kortex_description/meshes/base_link.STL",
+            ),
+            # Files outside the package are left untouched.
+            (f"file://{outside}", f"file://{outside}"),
+            (
+                "package://already_ok/meshes/keep.stl",
+                "package://already_ok/meshes/keep.stl",
+            ),
+            ("file:///opt/external/mesh.stl", "file:///opt/external/mesh.stl"),
+        ]
+
+        for filename, expected in cases:
+            with self.subTest(filename=filename):
+                self.assertEqual(
+                    _to_package_uri(
+                        filename,
+                        package_name="kortex_description",
+                        package_path=package_dir,
+                    ),
+                    expected,
+                )
+
+    def test_to_package_uri_names_package_not_repository(self):
+        # The URI names the package directory (e.g. "SE3"), not the
+        # repository clone that happens to contain it.
+        package_dir = "/tmp/stretch_urdf/stretch_urdf/SE3"
+        base_link = os.path.join(package_dir, "meshes", "base_link.STL")
+        self.assertEqual(
+            _to_package_uri(
+                f"file://{base_link}",
+                package_name="SE3",
+                package_path=package_dir,
+            ),
+            "package://SE3/meshes/base_link.STL",
+        )
+
+    def test_generated_urdf_filenames_are_normalized(self):
+        repo_dir = "/tmp/stretch_urdf"
+        package_dir = os.path.join(repo_dir, "stretch_urdf", "SE3")
+        base_link = os.path.join(package_dir, "meshes", "base_link.STL")
+        module = types.SimpleNamespace(
+            __name__="robot_descriptions.stretch_se3_description",
+            REPOSITORY_PATH=repo_dir,
+            PACKAGE_PATH=package_dir,
+        )
+        urdf_text = _convert_filenames_to_package_uris(
+            module,
+            "\n".join(
+                [
+                    "<robot name='generated'>",
+                    f"<mesh filename='file://{base_link}'/>",
+                    "<mesh filename='package://already_ok/meshes/keep.stl'/>",
+                    "<mesh filename='file:///opt/external/mesh.stl'/>",
+                    "</robot>",
+                ]
+            ),
+        )
+
+        self.assertIn(
+            "filename='package://SE3/meshes/base_link.STL'",
+            urdf_text,
+        )
+        self.assertIn(
+            "package://already_ok/meshes/keep.stl",
+            urdf_text,
+        )
+        self.assertIn("file:///opt/external/mesh.stl", urdf_text)


### PR DESCRIPTION
Xacro-generated URDFs baked absolute mesh paths into the cached file, making the cache non-relocatable and inconsistent with the `package://` resolution used elsewhere in the library.

This renders Xacro output with protocol paths preserved (xacrodoc ≥ 2.0) and rewrites package-local `file://` paths to stable `package://<package>/<rel>` URIs — named after the package directory and relative to it, so they stay valid package references wherever the cache lives. Existing `package://` references are left untouched, as are assets that live outside the package.

For example, a Stretch SE3 mesh reference:

```xml
<!-- before -->
<mesh filename="file:///home/user/.cache/robot_descriptions/stretch_urdf/stretch_urdf/SE3/meshes/base_link.STL"/>

<!-- after -->
<mesh filename="package://SE3/meshes/base_link.STL"/>
```

PyBullet resolves `package://` by walking up from the URDF file rather than against a package-dir list, so its loader resolves those URIs to absolute paths at load time.