### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-05
+
 ### Added
 
 - Description: Flexiv Rizon4 (MJCF)
@@ -15,8 +17,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Breaking:** `Description` constructor no longer takes a single `Format` as its first argument; pass `formats` as a set instead
+- **Breaking:** `Description` instances are now frozen
+- **Breaking:** `Description` now requires a `robot` field
 - Description metadata: Add robot name, maker, DOF, repository, and license fields to the registry (thanks to @nickswalker)
 - Description: Alphabetize description tables (thanks to @nickswalker)
+- Migrate `Description(Format.URDF, tags={...})` to `Description(formats={Format.URDF}, ...)`
 - README: Alphabetize description tables (thanks to @nickswalker)
 - README: Generate description tables from registry metadata and keep them alphabetized (thanks to @nickswalker)
 
@@ -618,7 +624,8 @@ This initial release includes 33 robot descriptions:
 - Contributing instructions
 - This changelog
 
-[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.23.0...HEAD
+[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.23.0...v2.0.0
 [1.23.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.20.0...v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Description: Flexiv Rizon4 (Xacro)
 - Description: Franka descriptions added XACRO_ARGS_NO_HAND property (thanks to @nickswalker)
 - Description: Robotiq 2F-85 v4 (URDF) (thanks to @nickswalker)
-- Description: SO-ARM101 Parallel Gripper (URDF)
+- Description: SO-ARM101 Parallel Gripper (URDF) (thanks to @brnikita)
 - Loaders: Allow overriding `XACRO_ARGS` via `load_robot_description` (thanks to @nickswalker)
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,3 +49,5 @@ authors:
 - family-names: "Walker"
   given-names: "Nick"
   orcid: "https://orcid.org/0000-0001-7711-0003"
+- family-names: "Bragin"
+  given-names: "Nikita"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "robot_descriptions.py: Robot descriptions in Python"
-version: 1.23.0
-date-released: 2026-03-09
+version: 2.0.0
+date-released: 2026-05-05
 url: "https://github.com/robot-descriptions/robot_descriptions.py"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ If you use this project in your works, please cite as follows:
 ```bibtex
 @software{robot_descriptions_py,
   title = {{robot_descriptions.py: Robot descriptions in Python}},
-  author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong and Walker, Nick},
+  author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong and Walker, Nick and Bragin, Nikita},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
   version = {1.23.0},

--- a/README.md
+++ b/README.md
@@ -391,8 +391,8 @@ If you use this project in your works, please cite as follows:
   author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong and Walker, Nick and Bragin, Nikita},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
-  version = {1.23.0},
-  year = {2025}
+  version = {2.0.0},
+  year = {2026}
 }
 ```
 

--- a/robot_descriptions/__init__.py
+++ b/robot_descriptions/__init__.py
@@ -8,6 +8,6 @@
 
 from ._descriptions import DESCRIPTIONS
 
-__version__ = "1.23.0"
+__version__ = "2.0.0"
 
 __all__ = ["DESCRIPTIONS"]


### PR DESCRIPTION
This release moves description metadata (robot name, maker, repository, license, ...) into the registry itself, using it to generate the README tables automatically. Thanks to @nickswalker for contributing this :+1: 

This is a major update since the `Description` dataclass signature has changed in the process. This update also surfaced a number of license inaccuracies that are now corrected.

This release also adds 5 robot descriptions, and allows overriding xacro args when calling `load_robot_description`. Thanks to @brnikita and @nickswalker for those :+1:

### Added

- Description: Flexiv Rizon4 (MJCF)
- Description: Flexiv Rizon4 (Xacro)
- Description: Franka descriptions added XACRO_ARGS_NO_HAND property (thanks to @nickswalker)
- Description: Robotiq 2F-85 v4 (URDF) (thanks to @nickswalker)
- Description: SO-ARM101 Parallel Gripper (URDF) (thanks to @brnikita)
- Loaders: Allow overriding `XACRO_ARGS` via `load_robot_description` (thanks to @nickswalker)

### Changed

- **Breaking:** `Description` constructor no longer takes a single `Format` as its first argument; pass `formats` as a set instead
- **Breaking:** `Description` instances are now frozen
- **Breaking:** `Description` now requires a `robot` field
- Description metadata: Add robot name, maker, DOF, repository, and license fields to the registry (thanks to @nickswalker)
- Description: Alphabetize description tables (thanks to @nickswalker)
- Migrate `Description(Format.URDF, tags={...})` to `Description(formats={Format.URDF}, ...)`
- README: Alphabetize description tables (thanks to @nickswalker)
- README: Generate description tables from registry metadata and keep them alphabetized (thanks to @nickswalker)

### Fixed

- README: Correct and backfill license metadata (thanks to @nickswalker)
- security: Bump gitpython to 3.1.49

### Migration notes

If you are updating code with custom `Description` instances to this new release, you should replace `Description(Format.URDF, tags={...})` with `Description(formats={Format.URDF}, robot="...", tags={...})`.