### PR TITLE
Transfer copyright notices to a `NOTICE` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Description: Patch Eve R3 URDF negative effort and velocity limit sentinels for loader compatibility (thanks to @nickswalker)
 - Description: TIAGo (URDF) now warns that it is deprecated and will switch to the official model in a later release
 - Description: Updated `franka_description` repository for SRDF Xacro updates
+- Transfer copyright notices to `NOTICE` file
 - Xacro: Support descriptions that resolve resources from multiple ROS packages (thanks to @nickswalker)
 
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,5 +35,6 @@ python scripts/generate_readme_descriptions.py
 
    - Use an [SPDX License Identifier](https://spdx.org/licenses/) in `license_spdx`.
    - When you know the license file location, store its repository-relative path in `license_file` so the README link can be derived automatically.
-7. **CHANGELOG:** Write down the new model at the top of the [changelog](CHANGELOG.md).
-8. **Testing:** Check that all unit tests are successful by `tox`.
+7. **Testing:** Check that all unit tests are successful by `tox`.
+8. **CHANGELOG:** Write down the new model at the top of the [changelog](CHANGELOG.md).
+9. **NOTICE:** If this is your first contribution, add a line `Copyright <YEAR> Your Name` to the [notice](NOTICE) file.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+This project includes contributions made under the following copyrights:
+
+- Copyright 2022 Giulio Romualdi
+- Copyright 2022 Stéphane Caron
+- Copyright 2023-2026 Inria
+- Copyright 2024 Jafar Uruç
+- Copyright 2024 Lev Kozlov
+- Copyright 2026 CNRS
+- Copyright 2026 Enactic, Inc.
+- Copyright 2026 Woojin Wie

--- a/examples/all_humanoids.py
+++ b/examples/all_humanoids.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 #
 # /// script
 # dependencies = ["meshcat", "pin", "robot_descriptions"]

--- a/examples/all_quadrupeds.py
+++ b/examples/all_quadrupeds.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 #
 # /// script
 # dependencies = ["meshcat", "pin", "robot_descriptions"]

--- a/examples/display_urdf_frames.py
+++ b/examples/display_urdf_frames.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["meshcat", "meshcat-shapes", "numpy", "pin", "robot_descriptions"]

--- a/examples/load_in_idyntree.py
+++ b/examples/load_in_idyntree.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Giulio Romualdi
 #
 # /// script
 # dependencies = ["idyntree", "robot_descriptions"]

--- a/examples/load_in_mujoco.py
+++ b/examples/load_in_mujoco.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["mujoco", "robot_descriptions"]

--- a/examples/load_in_pinocchio.py
+++ b/examples/load_in_pinocchio.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["pin", "robot_descriptions"]

--- a/examples/load_in_pybullet.py
+++ b/examples/load_in_pybullet.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["pybullet", "robot_descriptions"]

--- a/examples/load_in_robomeshcat.py
+++ b/examples/load_in_robomeshcat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["robomeshcat", "robot_descriptions"]

--- a/examples/load_in_yourdfpy.py
+++ b/examples/load_in_yourdfpy.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["yourdfpy", "robot_descriptions"]

--- a/examples/show_in_candlewick.py
+++ b/examples/show_in_candlewick.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 #
 # /// script
 # dependencies = ["pin", "robot_descriptions"]

--- a/examples/show_in_meshcat.py
+++ b/examples/show_in_meshcat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["meshcat", "pin", "robot_descriptions"]

--- a/examples/show_in_mujoco.py
+++ b/examples/show_in_mujoco.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["mujoco", "mujoco-python-viewer", "robot_descriptions"]

--- a/examples/show_in_pybullet.py
+++ b/examples/show_in_pybullet.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["pybullet", "robot_descriptions"]

--- a/examples/show_in_robomeshcat.py
+++ b/examples/show_in_robomeshcat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["numpy", "robomeshcat", "robot_descriptions"]

--- a/examples/show_in_yourdfpy.py
+++ b/examples/show_in_yourdfpy.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["yourdfpy", "robot_descriptions"]

--- a/examples/simulate_in_pybullet.py
+++ b/examples/simulate_in_pybullet.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 #
 # /// script
 # dependencies = ["pybullet", "robot_descriptions"]

--- a/examples/specific_commit.py
+++ b/examples/specific_commit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 #
 # /// script
 # dependencies = ["mujoco", "robot_descriptions"]

--- a/robot_descriptions/__init__.py
+++ b/robot_descriptions/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Import open source robot description as Python modules."""
 

--- a/robot_descriptions/__main__.py
+++ b/robot_descriptions/__main__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """List or show robot descriptions from the command line."""
 

--- a/robot_descriptions/_cache.py
+++ b/robot_descriptions/_cache.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Git utility functions to clone model repositories."""
 

--- a/robot_descriptions/_descriptions.py
+++ b/robot_descriptions/_descriptions.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """List of all robot descriptions and their metadata."""
 

--- a/robot_descriptions/_empty_description.py
+++ b/robot_descriptions/_empty_description.py
@@ -2,6 +2,5 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Empty description, used in unit tests."""

--- a/robot_descriptions/_package_dirs.py
+++ b/robot_descriptions/_package_dirs.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Giulio Romualdi
 
 import os.path
 from typing import List

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Git utility functions to clone model repositories."""
 

--- a/robot_descriptions/_xacro.py
+++ b/robot_descriptions/_xacro.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Inria
 
 """Utilities to resolve XML description files from Xacro sources."""
 

--- a/robot_descriptions/a1_description.py
+++ b/robot_descriptions/a1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """A1 description."""
 

--- a/robot_descriptions/a1_mj_description.py
+++ b/robot_descriptions/a1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """A1 MJCF description."""
 

--- a/robot_descriptions/ability_hand_description.py
+++ b/robot_descriptions/ability_hand_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Ability Hand description."""
 

--- a/robot_descriptions/adam_lite_mj_description.py
+++ b/robot_descriptions/adam_lite_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Adam Lite MJCF description."""
 

--- a/robot_descriptions/aliengo_description.py
+++ b/robot_descriptions/aliengo_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Aliengo description."""
 

--- a/robot_descriptions/aliengo_mj_description.py
+++ b/robot_descriptions/aliengo_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Aliengo description."""
 

--- a/robot_descriptions/allegro_hand_description.py
+++ b/robot_descriptions/allegro_hand_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Allegro Hand description."""
 

--- a/robot_descriptions/anymal_b_description.py
+++ b/robot_descriptions/anymal_b_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """ANYmal B description."""
 

--- a/robot_descriptions/anymal_b_mj_description.py
+++ b/robot_descriptions/anymal_b_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """ANYmal B MJCF description."""
 

--- a/robot_descriptions/anymal_c_description.py
+++ b/robot_descriptions/anymal_c_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """ANYmal C description."""
 

--- a/robot_descriptions/anymal_c_mj_description.py
+++ b/robot_descriptions/anymal_c_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """ANYmal C MJCF description."""
 

--- a/robot_descriptions/anymal_d_description.py
+++ b/robot_descriptions/anymal_d_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """ANYmal D description."""
 

--- a/robot_descriptions/apollo_mj_description.py
+++ b/robot_descriptions/apollo_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Apollo MJCF description."""
 

--- a/robot_descriptions/atlas_drc_description.py
+++ b/robot_descriptions/atlas_drc_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Atlas DRC (v3) description."""
 

--- a/robot_descriptions/atlas_v4_description.py
+++ b/robot_descriptions/atlas_v4_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Atlas v4 description."""
 

--- a/robot_descriptions/b1_description.py
+++ b/robot_descriptions/b1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """B1 description."""
 

--- a/robot_descriptions/b2_description.py
+++ b/robot_descriptions/b2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """B2 description."""
 

--- a/robot_descriptions/bambot_description.py
+++ b/robot_descriptions/bambot_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """BamBot description."""
 

--- a/robot_descriptions/barrett_hand_description.py
+++ b/robot_descriptions/barrett_hand_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """BarrettHand description."""
 

--- a/robot_descriptions/baxter_description.py
+++ b/robot_descriptions/baxter_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Baxter description."""
 

--- a/robot_descriptions/berkeley_humanoid_description.py
+++ b/robot_descriptions/berkeley_humanoid_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Berkeley Humanoid description."""
 

--- a/robot_descriptions/bolt_description.py
+++ b/robot_descriptions/bolt_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Bolt description."""
 

--- a/robot_descriptions/booster_t1_description.py
+++ b/robot_descriptions/booster_t1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Booster T1 description."""
 

--- a/robot_descriptions/booster_t1_mj_description.py
+++ b/robot_descriptions/booster_t1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Booster T1 MJCF description."""
 

--- a/robot_descriptions/cassie_description.py
+++ b/robot_descriptions/cassie_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Bolt description."""
 

--- a/robot_descriptions/cassie_mj_description.py
+++ b/robot_descriptions/cassie_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Cassie MJCF description."""
 

--- a/robot_descriptions/cf2_description.py
+++ b/robot_descriptions/cf2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Crazyflie 2.0 description."""
 

--- a/robot_descriptions/double_pendulum_description.py
+++ b/robot_descriptions/double_pendulum_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Double pendulum description."""
 

--- a/robot_descriptions/draco3_description.py
+++ b/robot_descriptions/draco3_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Draco3 description."""
 

--- a/robot_descriptions/edo_description.py
+++ b/robot_descriptions/edo_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """e.DO description."""
 

--- a/robot_descriptions/elf2_description.py
+++ b/robot_descriptions/elf2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Stéphane Caron
 
 """Elf2 description."""
 

--- a/robot_descriptions/elf2_mj_description.py
+++ b/robot_descriptions/elf2_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Elf2 MJCF description."""
 

--- a/robot_descriptions/ergocub_description.py
+++ b/robot_descriptions/ergocub_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 """ergoCub description."""
 

--- a/robot_descriptions/eve_r3_description.py
+++ b/robot_descriptions/eve_r3_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Eve R3 description."""
 

--- a/robot_descriptions/fanuc_m710ic_description.py
+++ b/robot_descriptions/fanuc_m710ic_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Fanuc M-710iC description."""
 

--- a/robot_descriptions/fetch_description.py
+++ b/robot_descriptions/fetch_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Fetch description."""
 

--- a/robot_descriptions/finger_edu_description.py
+++ b/robot_descriptions/finger_edu_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """FingerEdu v1 description."""
 

--- a/robot_descriptions/fr3_mj_description.py
+++ b/robot_descriptions/fr3_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Franka FR3 MJCF description."""
 

--- a/robot_descriptions/g1_mj_description.py
+++ b/robot_descriptions/g1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """G1 MJCF description."""
 

--- a/robot_descriptions/gen2_description.py
+++ b/robot_descriptions/gen2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Kinova Gen2 description."""
 

--- a/robot_descriptions/gen3_description.py
+++ b/robot_descriptions/gen3_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Kinova Gen3 description."""
 

--- a/robot_descriptions/gen3_lite_description.py
+++ b/robot_descriptions/gen3_lite_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Kinova Gen3 Lite description."""
 

--- a/robot_descriptions/gen3_mj_description.py
+++ b/robot_descriptions/gen3_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Kinova Gen3 MJCF description."""
 

--- a/robot_descriptions/ginger_description.py
+++ b/robot_descriptions/ginger_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Ginger description."""
 

--- a/robot_descriptions/go1_description.py
+++ b/robot_descriptions/go1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Go1 description."""
 

--- a/robot_descriptions/go1_mj_description.py
+++ b/robot_descriptions/go1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Unitree Go1 MJCF description."""
 

--- a/robot_descriptions/go2_description.py
+++ b/robot_descriptions/go2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Go2 description."""
 

--- a/robot_descriptions/go2_mj_description.py
+++ b/robot_descriptions/go2_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Unitree Go2 MJCF description."""
 

--- a/robot_descriptions/h1_description.py
+++ b/robot_descriptions/h1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """H1 description."""
 

--- a/robot_descriptions/h1_mj_description.py
+++ b/robot_descriptions/h1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Unitree H1 MJCF description."""
 

--- a/robot_descriptions/hyq_description.py
+++ b/robot_descriptions/hyq_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """HyQ description."""
 

--- a/robot_descriptions/icub_description.py
+++ b/robot_descriptions/icub_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """iCub description."""
 

--- a/robot_descriptions/iiwa14_description.py
+++ b/robot_descriptions/iiwa14_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """iiwa 14 description."""
 

--- a/robot_descriptions/iiwa7_description.py
+++ b/robot_descriptions/iiwa7_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """iiwa 7 description."""
 

--- a/robot_descriptions/jaxon_description.py
+++ b/robot_descriptions/jaxon_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """JAXON description."""
 

--- a/robot_descriptions/jvrc_description.py
+++ b/robot_descriptions/jvrc_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """JVRC-1 description."""
 

--- a/robot_descriptions/jvrc_mj_description.py
+++ b/robot_descriptions/jvrc_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """JVRC-1 MJCF description."""
 

--- a/robot_descriptions/laikago_description.py
+++ b/robot_descriptions/laikago_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Laikago description."""
 

--- a/robot_descriptions/leap_hand_v1_description.py
+++ b/robot_descriptions/leap_hand_v1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """LEAP hand v1 description."""
 

--- a/robot_descriptions/loaders/__init__.py
+++ b/robot_descriptions/loaders/__init__.py
@@ -2,6 +2,5 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Load robot descriptions for specific libraries."""

--- a/robot_descriptions/loaders/idyntree.py
+++ b/robot_descriptions/loaders/idyntree.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Giulio Romualdi
-# Copyright 2023 Inria
 
 """Load a robot description in iDynTree."""
 

--- a/robot_descriptions/loaders/mujoco.py
+++ b/robot_descriptions/loaders/mujoco.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Load a robot description in MuJoCo."""
 

--- a/robot_descriptions/loaders/pinocchio.py
+++ b/robot_descriptions/loaders/pinocchio.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Load a robot description in Pinocchio."""
 

--- a/robot_descriptions/loaders/pybullet.py
+++ b/robot_descriptions/loaders/pybullet.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Load a robot description in PyBullet."""
 

--- a/robot_descriptions/loaders/robomeshcat.py
+++ b/robot_descriptions/loaders/robomeshcat.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Load a robot description in `RoboMeshCat`_.
 

--- a/robot_descriptions/loaders/yourdfpy.py
+++ b/robot_descriptions/loaders/yourdfpy.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Load a robot description in yourdfpy."""
 

--- a/robot_descriptions/low_cost_robot_arm_mj_description.py
+++ b/robot_descriptions/low_cost_robot_arm_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Low-cost robot arm MJCF description."""
 

--- a/robot_descriptions/mini_cheetah_description.py
+++ b/robot_descriptions/mini_cheetah_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Mini Cheetah description."""
 

--- a/robot_descriptions/minitaur_description.py
+++ b/robot_descriptions/minitaur_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Minitaur description."""
 

--- a/robot_descriptions/mujoco_humanoid_mj_description.py
+++ b/robot_descriptions/mujoco_humanoid_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """MJCF description for the MuJoCo humanoid."""
 

--- a/robot_descriptions/nextage_description.py
+++ b/robot_descriptions/nextage_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """NEXTAGE description."""
 

--- a/robot_descriptions/omx_f_description.py
+++ b/robot_descriptions/omx_f_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OMX-F description."""
 

--- a/robot_descriptions/omx_l_description.py
+++ b/robot_descriptions/omx_l_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OMX-L description."""
 

--- a/robot_descriptions/omy_3m_description.py
+++ b/robot_descriptions/omy_3m_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OMY-3M description."""
 

--- a/robot_descriptions/omy_f3m_description.py
+++ b/robot_descriptions/omy_f3m_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OMY-F3M description."""
 

--- a/robot_descriptions/omy_l100_description.py
+++ b/robot_descriptions/omy_l100_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OMY-L100 description."""
 

--- a/robot_descriptions/open_manipulator_x_description.py
+++ b/robot_descriptions/open_manipulator_x_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Woojin Wie
 
 """OpenMANIPULATOR-X description."""
 

--- a/robot_descriptions/openarm_v1_mj_description.py
+++ b/robot_descriptions/openarm_v1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Enactic, Inc.
 
 """OpenArm 1.0 MJCF description."""
 

--- a/robot_descriptions/openarm_v2_mj_description.py
+++ b/robot_descriptions/openarm_v2_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Enactic, Inc.
 
 """OpenArm 2.0 MJCF description."""
 

--- a/robot_descriptions/panda_description.py
+++ b/robot_descriptions/panda_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Panda description."""
 

--- a/robot_descriptions/panda_mj_description.py
+++ b/robot_descriptions/panda_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Panda MJCF description."""
 

--- a/robot_descriptions/pepper_description.py
+++ b/robot_descriptions/pepper_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Pepper description."""
 

--- a/robot_descriptions/piper_description.py
+++ b/robot_descriptions/piper_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """PiPER description."""
 

--- a/robot_descriptions/piper_mj_description.py
+++ b/robot_descriptions/piper_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """PiPER MJCF description."""
 

--- a/robot_descriptions/poppy_ergo_jr_description.py
+++ b/robot_descriptions/poppy_ergo_jr_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Poppy Ergo Jr description."""
 

--- a/robot_descriptions/poppy_torso_description.py
+++ b/robot_descriptions/poppy_torso_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Poppy Torso description."""
 

--- a/robot_descriptions/pr2_description.py
+++ b/robot_descriptions/pr2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """PR2 description."""
 

--- a/robot_descriptions/r2_description.py
+++ b/robot_descriptions/r2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Robonaut 2 description."""
 

--- a/robot_descriptions/rby1_description.py
+++ b/robot_descriptions/rby1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Rainbow Robotics RBY1 URDF description."""
 

--- a/robot_descriptions/rby1_mj_description.py
+++ b/robot_descriptions/rby1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Rainbow Robotics RBY1 MJCF description."""
 

--- a/robot_descriptions/reachy_description.py
+++ b/robot_descriptions/reachy_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Reachy description."""
 

--- a/robot_descriptions/rhea_description.py
+++ b/robot_descriptions/rhea_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Rhea description."""
 

--- a/robot_descriptions/robotiq_2f85_description.py
+++ b/robot_descriptions/robotiq_2f85_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Robotiq 2F-85 description."""
 

--- a/robot_descriptions/robotiq_2f85_mj_description.py
+++ b/robot_descriptions/robotiq_2f85_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Robotiq 2F-85 MJCF description."""
 

--- a/robot_descriptions/robotiq_2f85_v4_mj_description.py
+++ b/robot_descriptions/robotiq_2f85_v4_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Robotiq 2F-85 MJCF description."""
 

--- a/robot_descriptions/romeo_description.py
+++ b/robot_descriptions/romeo_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Romeo description."""
 

--- a/robot_descriptions/rsk_description.py
+++ b/robot_descriptions/rsk_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """RSK omnidirection robot description."""
 

--- a/robot_descriptions/rsk_mj_description.py
+++ b/robot_descriptions/rsk_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """RSK omnidirection robot MJCF description."""
 

--- a/robot_descriptions/shadow_hand_mj_description.py
+++ b/robot_descriptions/shadow_hand_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Shadow Hand MJCF description."""
 

--- a/robot_descriptions/sigmaban_description.py
+++ b/robot_descriptions/sigmaban_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """SigmaBan description."""
 

--- a/robot_descriptions/simple_humanoid_description.py
+++ b/robot_descriptions/simple_humanoid_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Simple Humanoid description."""
 

--- a/robot_descriptions/skydio_x2_description.py
+++ b/robot_descriptions/skydio_x2_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Lev Kozlov
 
 """Skydio X2 description."""
 

--- a/robot_descriptions/skydio_x2_mj_description.py
+++ b/robot_descriptions/skydio_x2_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Lev Kozlov
 
 """Skydio X2 MJCF description."""
 

--- a/robot_descriptions/so_arm100_description.py
+++ b/robot_descriptions/so_arm100_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """SO-ARM100 description."""
 

--- a/robot_descriptions/so_arm100_mj_description.py
+++ b/robot_descriptions/so_arm100_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Jafar Uruç
 
 """SO-ARM100 MJCF description."""
 

--- a/robot_descriptions/solo_description.py
+++ b/robot_descriptions/solo_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Solo description."""
 

--- a/robot_descriptions/spot_mj_description.py
+++ b/robot_descriptions/spot_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Boston Dynamics Spot MJCF description."""
 

--- a/robot_descriptions/spryped_description.py
+++ b/robot_descriptions/spryped_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Spryped description."""
 

--- a/robot_descriptions/stretch_description.py
+++ b/robot_descriptions/stretch_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 """Stretch RE1 description."""
 

--- a/robot_descriptions/talos_description.py
+++ b/robot_descriptions/talos_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """TALOS description."""
 

--- a/robot_descriptions/tiago_description.py
+++ b/robot_descriptions/tiago_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """TIAGo description."""
 

--- a/robot_descriptions/trifinger_edu_description.py
+++ b/robot_descriptions/trifinger_edu_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """TriFingerEdu description."""
 

--- a/robot_descriptions/upkie_description.py
+++ b/robot_descriptions/upkie_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Upkie description."""
 

--- a/robot_descriptions/ur10e_mj_description.py
+++ b/robot_descriptions/ur10e_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """UR10e MJCF description."""
 

--- a/robot_descriptions/ur5e_mj_description.py
+++ b/robot_descriptions/ur5e_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """UR5e MJCF description."""
 

--- a/robot_descriptions/valkyrie_description.py
+++ b/robot_descriptions/valkyrie_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Valkyrie description."""
 

--- a/robot_descriptions/viper_mj_description.py
+++ b/robot_descriptions/viper_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """ViperX 300 6DOF MJCF description."""
 

--- a/robot_descriptions/widow_mj_description.py
+++ b/robot_descriptions/widow_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """WidowX 250 6DOF MJCF description."""
 

--- a/robot_descriptions/wl_p311d_description.py
+++ b/robot_descriptions/wl_p311d_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """WL P311D description."""
 

--- a/robot_descriptions/wl_p311e_description.py
+++ b/robot_descriptions/wl_p311e_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """WL P311E description."""
 

--- a/robot_descriptions/yam_description.py
+++ b/robot_descriptions/yam_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """YAM URDF description."""
 

--- a/robot_descriptions/yam_mj_description.py
+++ b/robot_descriptions/yam_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """YAM MJCF description."""
 

--- a/robot_descriptions/yumi_description.py
+++ b/robot_descriptions/yumi_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """YuMi description."""
 

--- a/robot_descriptions/z1_description.py
+++ b/robot_descriptions/z1_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Z1 description."""
 

--- a/robot_descriptions/z1_mj_description.py
+++ b/robot_descriptions/z1_mj_description.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Z1 MJCF description."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 from .test_clone_to_cache import TestCloneToCache
 from .test_clone_to_directory import TestCloneToDirectory

--- a/tests/loaders/test_idyntree.py
+++ b/tests/loaders/test_idyntree.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Giulio Romualdi
 
 import types
 import unittest

--- a/tests/loaders/test_mujoco.py
+++ b/tests/loaders/test_mujoco.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import unittest
 

--- a/tests/loaders/test_pinocchio.py
+++ b/tests/loaders/test_pinocchio.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import types
 import unittest

--- a/tests/loaders/test_pybullet.py
+++ b/tests/loaders/test_pybullet.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import types
 import unittest

--- a/tests/loaders/test_robomeshcat.py
+++ b/tests/loaders/test_robomeshcat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import types
 import unittest

--- a/tests/loaders/test_yourdfpy.py
+++ b/tests/loaders/test_yourdfpy.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import types
 import unittest

--- a/tests/test_clone_to_cache.py
+++ b/tests/test_clone_to_cache.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import os
 import tempfile

--- a/tests/test_clone_to_directory.py
+++ b/tests/test_clone_to_directory.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import os
 import tempfile

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import os
 import sys

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import unittest
 

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import unittest
 

--- a/tests/test_xacro.py
+++ b/tests/test_xacro.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Inria
 
 import os
 import shutil


### PR DESCRIPTION
This transfer keeps the information preserved while eliminating per-file clutter, reducing merge conflicts, and making attribution easier to maintain and review in one place.

The `NOTICE` file is described in section 4.4 of the Apache-2.0 license. See the how-to guide [Assembling LICENSE and NOTICE files](https://infra.apache.org/licensing-howto.html).