### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-07-11
+
 ### Added
 
 - Add support for SRDF descriptions (thanks to @nickswalker)
 - Description: Add SRDFs for Franka Emika robots: Panda, FER, FR3, FR3v2, FR3v2_1 (thanks to @nickswalker)
 - Description: Cookie wheeled biped (URDF)
 - Description: OpenArm v2 (MJCF) (thanks to @kou)
-- Description: RBY1 Mobile Manipulatior (MJCF)
+- Description: RBY1 Mobile Manipulator (MJCF)
 - Description: Stretch 4 (URDF) (thanks to @nickswalker)
 - Description: TIAGo official (URDF) (thanks to @nickswalker)
-- Description: Toyota HSR-B (URDF)
-- Description: Toyota HSR-C (URDF)
+- Description: Toyota HSR-B (URDF) (thanks to @nickswalker)
+- Description: Toyota HSR-C (URDF) (thanks to @nickswalker)
 
 ### Changed
 
@@ -26,16 +28,16 @@ All notable changes to this project will be documented in this file.
 - Transfer copyright notices to `NOTICE` file
 - Xacro: Support descriptions that resolve resources from multiple ROS packages (thanks to @nickswalker)
 
-### Removed
-
-- Description: remove deprecated UR3, UR5, and UR10 modules in favor of their official variants
-- Drop the Black formatter in favor of `ruff format`
-
 ### Fixed
 
 - security: Bump gitpython to 3.1.50
 - security: Bump idna from 3.14 to 3.15
 - security: Bump tornado from 6.5.5 to 6.5.7
+
+### Removed
+
+- **Breaking:** Remove deprecated UR3, UR5, and UR10 modules in favor of their official variants
+- Drop the Black formatter in favor of `ruff format`
 
 ## [2.0.0] - 2026-05-05
 
@@ -283,7 +285,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Upkie: Update repository to v2.1.0
+- Upkie: Update repository to v3.0.0
 
 ## [1.12.0] - 2024-08-08
 
@@ -657,39 +659,40 @@ This initial release includes 33 robot descriptions:
 - Contributing instructions
 - This changelog
 
-[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.23.0...v2.0.0
-[1.23.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.22.0...v1.23.0
-[1.22.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.21.0...v1.22.0
-[1.21.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.20.0...v1.21.0
-[1.20.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.19.0...v1.20.0
-[1.19.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.18.0...v1.19.0
-[1.18.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.17.0...v1.18.0
-[1.17.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.16.0...v1.17.0
-[1.16.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.15.0...v1.16.0
-[1.15.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.14.0...v1.15.0
-[1.14.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.13.0...v1.14.0
-[1.13.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.12.0...v1.13.0
-[1.12.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.11.0...v1.12.0
-[1.11.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.10.0...v1.11.0
-[1.10.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.9.0...v1.10.0
-[1.9.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.8.1...v1.9.0
-[1.8.1]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.8.0...v1.8.1
-[1.8.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.7.0...v1.8.0
-[1.7.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.6.0...v1.7.0
-[1.6.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.5.0...v1.6.0
-[1.5.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.4.1...v1.5.0
-[1.4.1]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.4.0...v1.4.1
-[1.4.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.3.1...v1.4.0
-[1.3.1]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.6.0...v1.0.0
-[0.6.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v0.1.0...v0.1.1
+[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v3.0.0
+[2.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v2.0.0
+[1.23.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.23.0
+[1.22.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.22.0
+[1.21.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.21.0
+[1.20.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.20.0
+[1.19.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.19.0
+[1.18.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.18.0
+[1.17.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.17.0
+[1.16.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.16.0
+[1.15.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.15.0
+[1.14.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.14.0
+[1.13.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.13.0
+[1.12.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.12.0
+[1.11.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.11.0
+[1.10.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/1.10.0
+[1.9.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.9.0
+[1.8.1]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.8.1
+[1.8.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.8.0
+[1.7.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.7.0
+[1.6.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.6.0
+[1.5.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.5.0
+[1.4.1]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.4.1
+[1.4.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.4.0
+[1.3.1]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.3.1
+[1.3.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.3.0
+[1.2.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.2.0
+[1.1.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.1.0
+[1.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.0.0
+[0.6.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.6.0
+[0.5.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.5.0
+[0.4.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.4.0
+[0.3.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.3.0
+[0.2.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.2.0
+[0.1.1]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.1.1
 [0.1.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "robot_descriptions.py: Robot descriptions in Python"
-version: 2.0.0
-date-released: 2026-05-05
+version: 3.0.0
+date-released: 2026-07-11
 url: "https://github.com/robot-descriptions/robot_descriptions.py"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If you use this project in your works, please cite as follows:
   author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong and Walker, Nick and Bragin, Nikita and Wie, Woojin},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
-  version = {2.0.0},
+  version = {3.0.0},
   year = {2026}
 }
 ```

--- a/robot_descriptions/__init__.py
+++ b/robot_descriptions/__init__.py
@@ -7,6 +7,6 @@
 
 from ._descriptions import DESCRIPTIONS
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = ["DESCRIPTIONS"]


### PR DESCRIPTION
This release adds support for SRDF descriptions, contributed by @nickswalker, along with SRDFs for the Franka Emika arms. It also brings 7 new descriptions, 3 security updates, and fixes to existing descriptions.

⚠️ Breaking: the deprecated UR3, UR5 and UR10 modules have been removed in favor of their official variants (they were actually slated for removal in 2.0.0). Make sure to switch to the official variants when upgrading.

Development and CI tooling has also switched from `tox` to `pixi`.

Thanks to @kou and @nickswalker for contributing to this release! :+1:

### Added

- Add support for SRDF descriptions (thanks to @nickswalker)
- Description: Add SRDFs for Franka Emika robots: Panda, FER, FR3, FR3v2, FR3v2_1 (thanks to @nickswalker)
- Description: Cookie wheeled biped (URDF)
- Description: OpenArm v2 (MJCF) (thanks to @kou)
- Description: RBY1 Mobile Manipulator (MJCF)
- Description: Stretch 4 (URDF) (thanks to @nickswalker)
- Description: TIAGo official (URDF) (thanks to @nickswalker)
- Description: Toyota HSR-B (URDF) (thanks to @nickswalker)
- Description: Toyota HSR-C (URDF) (thanks to @nickswalker)

### Changed

- CICD: Switch development and CI tooling from tox to pixi
- Description: Kinova Gen3 lite changed to use xacro (thanks to @nickswalker)
- Description: Patch Eve R3 URDF negative effort and velocity limit sentinels for loader compatibility (thanks to @nickswalker)
- Description: TIAGo (URDF) now warns that it is deprecated and will switch to the official model in a later release
- Description: Updated `franka_description` repository for SRDF Xacro updates
- Transfer copyright notices to `NOTICE` file
- Xacro: Support descriptions that resolve resources from multiple ROS packages (thanks to @nickswalker)

### Fixed

- security: Bump gitpython to 3.1.50
- security: Bump idna from 3.14 to 3.15
- security: Bump tornado from 6.5.5 to 6.5.7

### Removed

- **Breaking:** Remove deprecated UR3, UR5, and UR10 modules in favor of their official variants
- Drop the Black formatter in favor of `ruff format`
