### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-11
+
 ### Added
 
-- Description: GENE.01 (URDF)
+- Description: GENE.01 (URDF) (thanks to @traversaro)
 
 ### Fixed
 
@@ -667,7 +669,8 @@ This initial release includes 33 robot descriptions:
 - Contributing instructions
 - This changelog
 
-[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v3.0.0...HEAD
+[unreleased]: https://github.com/robot-descriptions/robot_descriptions.py/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v3.1.0
 [3.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v3.0.0
 [2.0.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v2.0.0
 [1.23.0]: https://github.com/robot-descriptions/robot_descriptions.py/releases/tag/v1.23.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "robot_descriptions.py: Robot descriptions in Python"
-version: 3.0.0
-date-released: 2026-07-11
+version: 3.1.0
+date-released: 2026-07-21
 url: "https://github.com/robot-descriptions/robot_descriptions.py"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ If you use this project in your works, please cite as follows:
   author = {Caron, Stéphane and Romualdi, Giulio and Kozlov, Lev and Ordoñez Apraez, Daniel Felipe and Tadashi Kussaba, Hugo and Bang, Seung Hyeon and Zakka, Kevin and Schramm, Fabian and Uru\c{c}, Jafar and Traversaro, Silvio and Zamora, Jonathan and Castro, Sebastian and Tao, Haixuan Xavier and Yu, Justin and Jallet, Wilson and Zhang, Yutong and Walker, Nick and Bragin, Nikita and Wie, Woojin},
   license = {Apache-2.0},
   url = {https://github.com/robot-descriptions/robot_descriptions.py},
-  version = {3.0.0},
+  version = {3.1.0},
   year = {2026}
 }
 ```

--- a/robot_descriptions/__init__.py
+++ b/robot_descriptions/__init__.py
@@ -7,6 +7,6 @@
 
 from ._descriptions import DESCRIPTIONS
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 __all__ = ["DESCRIPTIONS"]


### PR DESCRIPTION
This release adds the GENE.01 description and bumps GitPython to 3.1.52 for a security fix.

Thanks to @traversaro for contributing to this release 👍

### Added

- Description: GENE.01 (URDF) (thanks to @traversaro)

### Fixed

- security: Bump gitpython to 3.1.52