### PR TITLE
Add official PR2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Description: PR2 official (URDF) (thanks to @nickswalker)
+
+### Changed
+
+- Description: PR2 (URDF) now warns that it is deprecated and will switch to the official model in a later release (thanks to @nickswalker)
+
+
 ## [3.1.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -228,16 +228,17 @@ Descriptions may appear in more than one category when tags overlap.
 
 ### Dual arms
 
-| Name                        | Robot       | Maker            | DOF | Format | License                                                                                                                       |
-|-----------------------------|-------------|------------------|-----|--------|-------------------------------------------------------------------------------------------------------------------------------|
-| `aloha_mj_description`      | Aloha 2     | Trossen Robotics | 14  | MJCF   | [BSD-3-Clause](https://github.com/deepmind/mujoco_menagerie/blob/feadf76d42f8a2162426f7d226a3b539556b3bf5/aloha/LICENSE)      |
-| `baxter_description`        | Baxter      | Rethink Robotics | 15  | URDF   | [BSD-3-Clause](https://github.com/RethinkRobotics/baxter_common/blob/6c4b0f375fe4e356a3b12df26ef7c0d5e58df86e/LICENSE)        |
-| `nextage_description`       | NEXTAGE     | Kawada Robotics  | 15  | URDF   | [BSD](https://github.com/tork-a/rtmros_nextage/blob/ac270fb969fa54abeb6863f9b388a9e20c1f14e0/nextage_description/package.xml) |
-| `openarm_v1_mj_description` | OpenArm     | Enactic          | 16  | MJCF   | [Apache-2.0](https://github.com/enactic/openarm_mujoco/blob/5c6e1b4c71cbe27c6a4b58c7f198f080449e1b9c/LICENSE)                 |
-| `openarm_v2_mj_description` | OpenArm     | Enactic          | 16  | MJCF   | [Apache-2.0](https://github.com/enactic/openarm_mujoco/blob/5c6e1b4c71cbe27c6a4b58c7f198f080449e1b9c/LICENSE)                 |
-| `poppy_torso_description`   | Poppy Torso | Poppy Project    | 13  | URDF   | [GPL-3.0](https://github.com/poppy-project/poppy_torso_description/blob/6beeec3d76fb72b7548cce7c73aad722f8884522/package.xml) |
-| `pr2_description`           | PR2         | Willow Garage    |     | URDF   | [BSD](https://github.com/ankurhanda/robot-assets/blob/12f1a3c89c9975194551afaed0dfae1e09fdb27c/README.md)                     |
-| `yumi_description`          | YuMi        | ABB              | 16  | URDF   | [BSD](https://github.com/ankurhanda/robot-assets/blob/12f1a3c89c9975194551afaed0dfae1e09fdb27c/README.md)                     |
+| Name                        | Robot          | Maker            | DOF | Format | License                                                                                                                       |
+|-----------------------------|----------------|------------------|-----|--------|-------------------------------------------------------------------------------------------------------------------------------|
+| `aloha_mj_description`      | Aloha 2        | Trossen Robotics | 14  | MJCF   | [BSD-3-Clause](https://github.com/deepmind/mujoco_menagerie/blob/feadf76d42f8a2162426f7d226a3b539556b3bf5/aloha/LICENSE)      |
+| `baxter_description`        | Baxter         | Rethink Robotics | 15  | URDF   | [BSD-3-Clause](https://github.com/RethinkRobotics/baxter_common/blob/6c4b0f375fe4e356a3b12df26ef7c0d5e58df86e/LICENSE)        |
+| `nextage_description`       | NEXTAGE        | Kawada Robotics  | 15  | URDF   | [BSD](https://github.com/tork-a/rtmros_nextage/blob/ac270fb969fa54abeb6863f9b388a9e20c1f14e0/nextage_description/package.xml) |
+| `openarm_v1_mj_description` | OpenArm        | Enactic          | 16  | MJCF   | [Apache-2.0](https://github.com/enactic/openarm_mujoco/blob/5c6e1b4c71cbe27c6a4b58c7f198f080449e1b9c/LICENSE)                 |
+| `openarm_v2_mj_description` | OpenArm        | Enactic          | 16  | MJCF   | [Apache-2.0](https://github.com/enactic/openarm_mujoco/blob/5c6e1b4c71cbe27c6a4b58c7f198f080449e1b9c/LICENSE)                 |
+| `poppy_torso_description`   | Poppy Torso    | Poppy Project    | 13  | URDF   | [GPL-3.0](https://github.com/poppy-project/poppy_torso_description/blob/6beeec3d76fb72b7548cce7c73aad722f8884522/package.xml) |
+| `pr2_description`           | PR2            | Willow Garage    |     | URDF   | [BSD](https://github.com/ankurhanda/robot-assets/blob/12f1a3c89c9975194551afaed0dfae1e09fdb27c/README.md)                     |
+| `pr2_official_description`  | PR2 (official) | Willow Garage    |     | URDF   | [BSD](https://github.com/PR2/pr2_common/blob/9a8e4fbcf66523ca14faf651c23513ee1ac29ccb/pr2_description/package.xml)            |
+| `yumi_description`          | YuMi           | ABB              | 16  | URDF   | [BSD](https://github.com/ankurhanda/robot-assets/blob/12f1a3c89c9975194551afaed0dfae1e09fdb27c/README.md)                     |
 
 ### Drones
 
@@ -334,6 +335,7 @@ Descriptions may appear in more than one category when tags overlap.
 | `hsrc_description`           | HSR-C            | Toyota Motor Corporation | URDF   | [BSD-3-Clause-Clear](https://github.com/hsr-project/hsrb_common/blob/5ad6946064b6031a2dd90be926e4d9b77f84d785/LICENSE.txt)                           |
 | `pepper_description`         | Pepper           | SoftBank Robotics        | URDF   | [BSD-2-Clause](https://github.com/jrl-umi3218/pepper_description/blob/cd9715bb5df7ad57445d953db7b1924255305944/LICENSE)                              |
 | `pr2_description`            | PR2              | Willow Garage            | URDF   | [BSD](https://github.com/ankurhanda/robot-assets/blob/12f1a3c89c9975194551afaed0dfae1e09fdb27c/README.md)                                            |
+| `pr2_official_description`   | PR2 (official)   | Willow Garage            | URDF   | [BSD](https://github.com/PR2/pr2_common/blob/9a8e4fbcf66523ca14faf651c23513ee1ac29ccb/pr2_description/package.xml)                                   |
 | `rby1_description`           | RBY1             | Rainbow Robotics         | URDF   | [MIT](https://github.com/uynitsuj/rby1_description/blob/e4c07203aa0a0d1b6b3b39da105cb00a77e2bc72/LICENSE)                                            |
 | `rby1_mj_description`        | RBY1             | Rainbow Robotics         | MJCF   | [MIT](https://github.com/uynitsuj/rby1_description/blob/e4c07203aa0a0d1b6b3b39da105cb00a77e2bc72/LICENSE)                                            |
 | `reachy_description`         | Reachy           | Pollen Robotics          | URDF   | [Apache-2.0](https://github.com/aubrune/reachy_description/blob/release-1.0.0/LICENSE)                                                               |

--- a/robot_descriptions/_descriptions.py
+++ b/robot_descriptions/_descriptions.py
@@ -1108,6 +1108,15 @@ DESCRIPTIONS: Dict[str, Description] = {
         license_spdx="BSD",
         license_file="README.md",
     ),
+    "pr2_official_description": Description(
+        formats={Format.URDF},
+        tags={"dual_arm", "mobile_manipulator"},
+        robot="PR2 (official)",
+        maker="Willow Garage",
+        repository="pr2_common",
+        license_spdx="BSD",
+        license_file="pr2_description/package.xml",
+    ),
     "r2_description": Description(
         formats={Format.URDF},
         tags={"humanoid"},

--- a/robot_descriptions/_repositories.py
+++ b/robot_descriptions/_repositories.py
@@ -297,6 +297,11 @@ REPOSITORIES: Dict[str, Repository] = {
         commit="6beeec3d76fb72b7548cce7c73aad722f8884522",
         cache_path="poppy_torso_description",
     ),
+    "pr2_common": Repository(
+        url="https://github.com/PR2/pr2_common.git",
+        commit="9a8e4fbcf66523ca14faf651c23513ee1ac29ccb",
+        cache_path="pr2_common",
+    ),
     "rby1_description": Repository(
         url="https://github.com/uynitsuj/rby1_description.git",
         commit="e4c07203aa0a0d1b6b3b39da105cb00a77e2bc72",

--- a/robot_descriptions/pr2_description.py
+++ b/robot_descriptions/pr2_description.py
@@ -5,10 +5,19 @@
 
 """PR2 description."""
 
+import warnings as _warnings
 from os import getenv as _getenv
 from os import path as _path
 
 from ._cache import clone_to_cache as _clone_to_cache
+
+_warnings.warn(
+    "robot_descriptions.pr2_description is deprecated and will switch to "
+    "the official PR2 model in robot_descriptions.py in a later release. "
+    "Use robot_descriptions.pr2_official_description now to migrate early.",
+    FutureWarning,
+    stacklevel=2,
+)
 
 REPOSITORY_PATH: str = _clone_to_cache(
     "robot-assets",

--- a/robot_descriptions/pr2_official_description.py
+++ b/robot_descriptions/pr2_official_description.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Official PR2 description."""
+
+from os import getenv as _getenv
+from os import path as _path
+
+from ._cache import clone_to_cache as _clone_to_cache
+
+REPOSITORY_PATH: str = _clone_to_cache(
+    "pr2_common",
+    commit=_getenv("ROBOT_DESCRIPTION_COMMIT", None),
+)
+
+PACKAGE_PATH: str = _path.join(REPOSITORY_PATH, "pr2_description")
+
+XACRO_PATH: str = _path.join(PACKAGE_PATH, "robots", "pr2.urdf.xacro")
+
+XACRO_ARGS = {
+    "KINECT1": "false",
+    "KINECT2": "false",
+}
+
+XACRO_PACKAGE_PATHS: dict[str, str] = {
+    "pr2_description": PACKAGE_PATH,
+}


### PR DESCRIPTION
One of the last few "unofficial" models. The official xacro-based model adds sensor links as well as some mechanical links/frames that were trimmed off the unofficial model.

Pending idyntree gracefully handling references to textures https://github.com/gbionics/idyntree/issues/1301